### PR TITLE
cleanup-schema

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -11,6 +11,7 @@ Mostly internal classes were moved to semantically more appropriate locations.
   - Reorganized `algomancy-gui` internals 
 - Refinement of `Schema` class
   - **[Breaking]** Moved `_defined_datatypes` to `_DATATYPES` as class attribute to define the datatypes of each column.
+  - `Schema`s no longer need to be instantiated before being passed to the configuration. Passing types to the configuration is now possible; passing instances still works. 
 
 ### Fixed
 

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -5,9 +5,12 @@ Mostly internal classes were moved to semantically more appropriate locations.
 ### Added
 
 ### Changed
-- **[Breaking]** Moved `BasePage` and subclasses to `algomancy_gui`; imports have to be updated appropriately
-- Moved `LibraryManager` to `algomancy-gui` from `algomancy-content`
-- Reorganized `algomancy-gui` internals 
+- Cleanup of dependencies between `algomancy-content` and `algomancy-gui`
+  - **[Breaking]** Moved `BasePage` and subclasses to `algomancy_gui`; imports have to be updated appropriately
+  - Moved `LibraryManager` to `algomancy-gui` from `algomancy-content`
+  - Reorganized `algomancy-gui` internals 
+- Refinement of `Schema` class
+  - **[Breaking]** Moved `_defined_datatypes` to `_DATATYPES` as class attribute to define the datatypes of each column.
 
 ### Fixed
 

--- a/docs/source/tutorial/etl.md
+++ b/docs/source/tutorial/etl.md
@@ -22,7 +22,7 @@ The fields `_FILENAME`, `_EXTENSION` and `_SCHEMA_TYPE` must be provided. If not
 ```
 1. Create a file `schemas.py `in the directory `src/data_handling/`
 2. For each table in an input file (could be multiple in an Excel), create a `Schema` subclass in `schemas.py`. 
-This field `_defined_datatypes` defines the table structure, and must be implemented by the subclass:
+This field `_DATATYPES` defines the table structure, and must be implemented by the subclass:
 :::{dropdown} {octicon}`code` Code
 :color: info
 
@@ -45,12 +45,11 @@ class DCSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            DCSchema.ID: DataType.STRING,
-            DCSchema.X: DataType.INTEGER,
-            DCSchema.Y: DataType.INTEGER,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        X: DataType.INTEGER,
+        Y: DataType.INTEGER,
+    }
 
 
 class LocationSchema(Schema):
@@ -62,19 +61,18 @@ class LocationSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, Dict[str, DataType]]:
-        return {
-           "customer": {
-               LocationSchema.ID: DataType.STRING,
-               LocationSchema.X: DataType.INTEGER,
-               LocationSchema.Y: DataType.INTEGER,
-            },
-           "xdock": {
-               LocationSchema.ID: DataType.STRING,
-               LocationSchema.X: DataType.INTEGER,
-               LocationSchema.Y: DataType.INTEGER,
-            },
-        }
+    _DATATYPES = {
+        "customer": {
+            ID: DataType.STRING,
+            X: DataType.INTEGER,
+            Y: DataType.INTEGER,
+        },
+        "xdock": {
+            ID: DataType.STRING,
+            X: DataType.INTEGER,
+            Y: DataType.INTEGER,
+        },
+    }
 
 
 
@@ -87,12 +85,11 @@ class StoresSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            StoresSchema.ID: DataType.STRING,
-            StoresSchema.X: DataType.INTEGER,
-            StoresSchema.Y: DataType.INTEGER,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        X: DataType.INTEGER,
+        Y: DataType.INTEGER,
+    }
 ```
 :::
 
@@ -100,7 +97,7 @@ class StoresSchema(Schema):
 A single `Schema` is associated with a single file. 
 In case a single file contains more than one data table (e.g., multiple Excel tabs), we should take care that:
 - the `_SCHEMA_TYPE` is set to `MULTI`,
-- `_defined_datatypes` returns a nested dictionary, such as on lines 34-46 of the code block above, and
+- `_DATATYPES` defines a nested dictionary, such as on lines 64-75 of the code block above, and
 - the keys of the outer dictionary corresponds to the identifyers of the input tables (e.g., each sheet name of an xlsx)
 ```
 

--- a/example/data_handling/schemas.py
+++ b/example/data_handling/schemas.py
@@ -164,8 +164,8 @@ class LocationSchema(Schema):
 
 
 example_schemas = [
-    WarehouseLayoutSchema,
-    ItemDataSchema,
+    WarehouseLayoutSchema(),
+    ItemDataSchema(),
     InventorySchema,
     EmployeeDataSchema,
     LocationSchema,

--- a/example/data_handling/schemas.py
+++ b/example/data_handling/schemas.py
@@ -164,9 +164,9 @@ class LocationSchema(Schema):
 
 
 example_schemas = [
-    WarehouseLayoutSchema(),
-    ItemDataSchema(),
-    InventorySchema(),
-    EmployeeDataSchema(),
-    LocationSchema(),
+    WarehouseLayoutSchema,
+    ItemDataSchema,
+    InventorySchema,
+    EmployeeDataSchema,
+    LocationSchema,
 ]

--- a/example/data_handling/schemas.py
+++ b/example/data_handling/schemas.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from algomancy_data import Schema, FileExtension, DataType
 from algomancy_data.schema import SchemaType
 
@@ -16,13 +14,12 @@ class WarehouseLayoutSchema(Schema):
     Y = "y"
     ZONE = "zone"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            WarehouseLayoutSchema.ID: DataType.STRING,
-            WarehouseLayoutSchema.ZONE: DataType.STRING,
-            WarehouseLayoutSchema.X: DataType.FLOAT,
-            WarehouseLayoutSchema.Y: DataType.FLOAT,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        ZONE: DataType.STRING,
+        X: DataType.FLOAT,
+        Y: DataType.FLOAT,
+    }
 
 
 class ItemDataSchema(Schema):
@@ -42,18 +39,17 @@ class ItemDataSchema(Schema):
     CURRENT_SLOT = "currentslot"
     OPTIMAL_SLOT = "optimalslot"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            ItemDataSchema.ID: DataType.STRING,
-            ItemDataSchema.SKU: DataType.STRING,
-            ItemDataSchema.DESCRIPTION: DataType.STRING,
-            ItemDataSchema.CATEGORY: DataType.STRING,
-            ItemDataSchema.DAILY_PICKS: DataType.INTEGER,
-            ItemDataSchema.VOLUME_CM3: DataType.FLOAT,
-            ItemDataSchema.WEIGHT_KG: DataType.FLOAT,
-            ItemDataSchema.CURRENT_SLOT: DataType.STRING,
-            ItemDataSchema.OPTIMAL_SLOT: DataType.STRING,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        SKU: DataType.STRING,
+        DESCRIPTION: DataType.STRING,
+        CATEGORY: DataType.STRING,
+        DAILY_PICKS: DataType.INTEGER,
+        VOLUME_CM3: DataType.FLOAT,
+        WEIGHT_KG: DataType.FLOAT,
+        CURRENT_SLOT: DataType.STRING,
+        OPTIMAL_SLOT: DataType.STRING,
+    }
 
 
 class EmployeeDataSchema(Schema):
@@ -75,20 +71,19 @@ class EmployeeDataSchema(Schema):
     position = "attributes.position"
     skills = "attributes.skills"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            EmployeeDataSchema.ID: DataType.STRING,
-            EmployeeDataSchema.name: DataType.STRING,
-            EmployeeDataSchema.email: DataType.STRING,
-            EmployeeDataSchema.hire_date: DataType.DATETIME,
-            EmployeeDataSchema.last_login: DataType.DATETIME,
-            EmployeeDataSchema.dates_with_typo: DataType.DATETIME,
-            EmployeeDataSchema.is_active: DataType.BOOLEAN,
-            EmployeeDataSchema.age: DataType.INTEGER,
-            EmployeeDataSchema.department: DataType.STRING,
-            EmployeeDataSchema.position: DataType.STRING,
-            EmployeeDataSchema.skills: DataType.STRING,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        name: DataType.STRING,
+        email: DataType.STRING,
+        hire_date: DataType.DATETIME,
+        last_login: DataType.DATETIME,
+        dates_with_typo: DataType.DATETIME,
+        is_active: DataType.BOOLEAN,
+        age: DataType.INTEGER,
+        department: DataType.STRING,
+        position: DataType.STRING,
+        skills: DataType.STRING,
+    }
 
 
 class InventorySchema(Schema):
@@ -119,29 +114,28 @@ class InventorySchema(Schema):
     SAFETY_STOCK = "Safety\nStock"
     VALUE_BASED_ON_SAFETY_STOCK = "Value \nBased on \nSafety Stock"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            InventorySchema.BRANCH: DataType.STRING,
-            InventorySchema.LOCATION_TYPE: DataType.STRING,
-            InventorySchema.LOCATION: DataType.STRING,
-            InventorySchema.ITEM_NUMBER: DataType.STRING,
-            InventorySchema.ITEM_DESCRIPTION: DataType.STRING,
-            InventorySchema.ITEM_DESCRIPTION_2: DataType.STRING,
-            InventorySchema.LOT_SERIAL_NUMBER: DataType.STRING,
-            InventorySchema.IB_SETUP_STATUS: DataType.STRING,
-            InventorySchema.TECHNICAL_STATUS: DataType.STRING,
-            InventorySchema.STOCKING_TYPE: DataType.STRING,
-            InventorySchema.LINE_TYPE: DataType.STRING,
-            InventorySchema.MASTER_PLANNING_FAMILY: DataType.STRING,
-            InventorySchema.INVENTORY_COST_SELECTOR: DataType.STRING,
-            InventorySchema.GL_CATEGORY: DataType.STRING,
-            InventorySchema.UOM_PRIMARY: DataType.STRING,
-            InventorySchema.UNIT_COST: DataType.FLOAT,
-            InventorySchema.QUANTITY_ON_HAND: DataType.FLOAT,
-            InventorySchema.INVENTORY_VALUE: DataType.FLOAT,
-            InventorySchema.SAFETY_STOCK: DataType.FLOAT,
-            InventorySchema.VALUE_BASED_ON_SAFETY_STOCK: DataType.FLOAT,
-        }
+    _DATATYPES = {
+        BRANCH: DataType.STRING,
+        LOCATION_TYPE: DataType.STRING,
+        LOCATION: DataType.STRING,
+        ITEM_NUMBER: DataType.STRING,
+        ITEM_DESCRIPTION: DataType.STRING,
+        ITEM_DESCRIPTION_2: DataType.STRING,
+        LOT_SERIAL_NUMBER: DataType.STRING,
+        IB_SETUP_STATUS: DataType.STRING,
+        TECHNICAL_STATUS: DataType.STRING,
+        STOCKING_TYPE: DataType.STRING,
+        LINE_TYPE: DataType.STRING,
+        MASTER_PLANNING_FAMILY: DataType.STRING,
+        INVENTORY_COST_SELECTOR: DataType.STRING,
+        GL_CATEGORY: DataType.STRING,
+        UOM_PRIMARY: DataType.STRING,
+        UNIT_COST: DataType.FLOAT,
+        QUANTITY_ON_HAND: DataType.FLOAT,
+        INVENTORY_VALUE: DataType.FLOAT,
+        SAFETY_STOCK: DataType.FLOAT,
+        VALUE_BASED_ON_SAFETY_STOCK: DataType.FLOAT,
+    }
 
 
 class LocationSchema(Schema):
@@ -157,17 +151,16 @@ class LocationSchema(Schema):
     ID = "ID"
     Name = "Naam"
 
-    def _defined_datatypes(self) -> Dict[str, Dict[str, DataType]]:
-        return {
-            "Steden": {
-                LocationSchema.COUNTRY: DataType.STRING,
-                LocationSchema.CITY: DataType.STRING,
-            },
-            "Klanten": {
-                LocationSchema.ID: DataType.INTEGER,
-                LocationSchema.Name: DataType.STRING,
-            },
-        }
+    _DATATYPES = {
+        "Steden": {
+            COUNTRY: DataType.STRING,
+            CITY: DataType.STRING,
+        },
+        "Klanten": {
+            ID: DataType.INTEGER,
+            Name: DataType.STRING,
+        },
+    }
 
 
 example_schemas = [

--- a/example/main.py
+++ b/example/main.py
@@ -98,7 +98,7 @@ def main(
     GuiLauncher.run(
         app=app,
         host=app_cfg.host,
-        port=app_cfg.port,
+        port=8051,
         threads=threads,
         connection_limit=connection_limit,
         debug=debug,

--- a/packages/algomancy-content/src/algomancy_content/backend/placeholderschema.py
+++ b/packages/algomancy-content/src/algomancy_content/backend/placeholderschema.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 from algomancy_data import (
     Schema,
     DataType,
@@ -15,15 +13,13 @@ class PlaceholderSchema(Schema):
     _EXTENSION = FileExtension.CSV
     _SCHEMA = SchemaType.SINGLE
 
-    @property
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            "id": DataType.INTEGER,
-            "name": DataType.STRING,
-            "age": DataType.INTEGER,
-            "city": DataType.STRING,
-            "department": DataType.STRING,
-            "salary": DataType.INTEGER,
-            "hire_date": DataType.DATETIME,
-            "performance_score": DataType.FLOAT,
-        }
+    _DATATYPES = {
+        "id": DataType.INTEGER,
+        "name": DataType.STRING,
+        "age": DataType.INTEGER,
+        "city": DataType.STRING,
+        "department": DataType.STRING,
+        "salary": DataType.INTEGER,
+        "hire_date": DataType.DATETIME,
+        "performance_score": DataType.FLOAT,
+    }

--- a/packages/algomancy-data/src/algomancy_data/etl.py
+++ b/packages/algomancy-data/src/algomancy_data/etl.py
@@ -8,7 +8,7 @@ for a concrete dataset configuration.
 # --- Abstract Factory ---
 from algomancy_data.transformer import TransformationSequence
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from typing import Dict, List, Type
 
 from algomancy_utils import Logger
 
@@ -93,7 +93,7 @@ class ETLConstructionError(Exception):
 class ETLFactory(ABC):
     """Abstract factory that constructs ETL sequences and loader."""
 
-    def __init__(self, schemas: List[Schema], logger):
+    def __init__(self, schemas: List[Type[Schema]], logger):
         self.schemas = schemas
         self.logger = logger
 

--- a/packages/algomancy-data/src/algomancy_data/extractor.py
+++ b/packages/algomancy-data/src/algomancy_data/extractor.py
@@ -481,12 +481,12 @@ class XLSXMultiExtractor(MultiExtractor):
     ) -> None:
         super().__init__(file, schema, logger)
         self._sheet_names = list(self.schema.sub_names)
-        self._single_sheet_extractors = {
-            sheet_name: XLSXSingleExtractor(
-                file, schema.generate_subschema(sheet_name), sheet_name
+        self._single_sheet_extractors = {}
+        for sheet_name in self._sheet_names:
+            subschema = self.schema.get_subschema(sheet_name)
+            self._single_sheet_extractors[sheet_name] = XLSXSingleExtractor(
+                file, subschema, sheet_name
             )
-            for sheet_name in self._sheet_names
-        }
 
     def _extract_files(self) -> Dict[str, pd.DataFrame]:
         dfs = {}

--- a/packages/algomancy-data/src/algomancy_data/schema.py
+++ b/packages/algomancy-data/src/algomancy_data/schema.py
@@ -7,7 +7,7 @@ that all declared fields have a specified ``DataType``.
 """
 
 import inspect
-from abc import ABC, abstractmethod
+from abc import ABC
 from enum import StrEnum
 from typing import Dict, List
 
@@ -53,6 +53,9 @@ class Schema(ABC):
     _SCHEMA_TYPE: SchemaType | str = (
         "default_schema_type"  # expected to be overridden by subclasses
     )
+    _DATATYPES: Dict[str, DataType] | Dict[str, Dict[str, DataType]] | str = (
+        "default_datatypes"
+    )
 
     def __init__(self, subschema_key: str | None = None) -> None:
         self._subschema_key = subschema_key
@@ -95,21 +98,24 @@ class Schema(ABC):
     def file_name_with_extension(self) -> str:
         return self._FILENAME + "." + self._EXTENSION
 
-    @abstractmethod
-    def _defined_datatypes(
-        self,
-    ) -> Dict[str, DataType] | Dict[str, Dict[str, DataType]]:
-        raise NotImplementedError("Abstract method")
-
     @property
     def datatypes(self) -> Dict[str, DataType]:
+        # Check implementation
+        if self._DATATYPES == "default_datatypes":
+            raise NotImplementedError("_DATATYPES must be overridden by subclasses")
+
         if self.is_multi() and self._subschema_key is not None:
-            dtypes = self._defined_datatypes()[self._subschema_key]  # noqa
+            dtypes = self._DATATYPES[self._subschema_key]  # noqa
         elif self.is_single():
-            dtypes = self._defined_datatypes()
+            dtypes = self._DATATYPES
         else:
             raise ValueError("Method is only available for single schemas")
 
+        self._validate_datatypes(dtypes)
+
+        return dtypes
+
+    def _validate_datatypes(self, dtypes: dict[str, DataType]) -> None:
         # for single schema type: the return value must be Dict[str,DataType]
         dtypes: Dict[str, DataType]
         for field, dtype in dtypes.items():
@@ -120,16 +126,16 @@ class Schema(ABC):
                 f"Datatype for field '{field}' must be a DataType, got {type(dtype)}"
             )
 
-        # return
-        return dtypes
-
     @property
     def datatype_groups(self) -> Dict[str, Dict[str, DataType]]:
         if not self.is_multi():
             raise ValueError("Method is only available for multi schemas")
 
         # grab from implementation
-        dtypes = self._defined_datatypes()
+        if self._DATATYPES == "default_datatypes":
+            raise NotImplementedError("_DATATYPES must be overridden by subclasses")
+
+        dtypes = self._DATATYPES
 
         # for multi-schema type: the return value must be Dict[str,Dict[str,DataType]]
         dtypes: Dict[str, Dict[str, DataType]]

--- a/packages/algomancy-data/src/algomancy_data/schema.py
+++ b/packages/algomancy-data/src/algomancy_data/schema.py
@@ -39,6 +39,22 @@ class SchemaType(StrEnum):
     MULTI = "multi"
 
 
+class classproperty(property):
+    """
+    A decorator that creates a property accessible from both class and instances.
+
+    When accessed from the class, passes the class to the decorated method.
+    When accessed from an instance, passes the instance to the decorated method.
+    """
+
+    def __get__(self, instance, owner):
+        # If accessed from an instance, pass the instance
+        if instance is not None:
+            return self.fget(instance)
+        # If accessed from the class, pass the class
+        return self.fget(owner)
+
+
 class Schema(ABC):
     """Abstract base class for table schemas.
 
@@ -60,62 +76,65 @@ class Schema(ABC):
     def __init__(self, subschema_key: str | None = None) -> None:
         self._subschema_key = subschema_key
 
-    @property
-    def file_name(self) -> str:
+    @classproperty
+    def file_name(cls) -> str:
         """Return the file name of the schema."""
-        if self._FILENAME == "default_filename":
+        if cls._FILENAME == "default_filename":
             raise NotImplementedError("_FILENAME must be overridden by subclasses")
 
-        return self._FILENAME
+        return cls._FILENAME
 
-    @property
-    def extension(self) -> FileExtension:
+    @classproperty
+    def extension(cls) -> FileExtension:
         """Return the file extension of the schema."""
-        if self._EXTENSION == "default_extension":
+        if cls._EXTENSION == "default_extension":
             raise NotImplementedError("_EXTENSION must be overridden by subclasses")
 
-        if isinstance(self._EXTENSION, FileExtension):
-            return self._EXTENSION
-        elif isinstance(self._EXTENSION, str):
-            return FileExtension(self._EXTENSION)
+        if isinstance(cls._EXTENSION, FileExtension):
+            return cls._EXTENSION
+        elif isinstance(cls._EXTENSION, str):
+            return FileExtension(cls._EXTENSION)
         else:
-            raise TypeError(f"Invalid extension type: {type(self._EXTENSION)}")
+            raise TypeError(f"Invalid extension type: {type(cls._EXTENSION)}")
 
-    @property
-    def schema_type(self) -> SchemaType:
+    @classproperty
+    def schema_type(cls) -> SchemaType:
         """Return the schema type of the schema."""
-        if self._SCHEMA_TYPE == "default_schema_type":
+        if cls._SCHEMA_TYPE == "default_schema_type":
             raise NotImplementedError("_SCHEMA_TYPE must be overridden by subclasses")
 
-        if isinstance(self._SCHEMA_TYPE, SchemaType):
-            return self._SCHEMA_TYPE
-        elif isinstance(self._SCHEMA_TYPE, str):
-            return SchemaType(self._SCHEMA_TYPE)
+        if isinstance(cls._SCHEMA_TYPE, SchemaType):
+            return cls._SCHEMA_TYPE
+        elif isinstance(cls._SCHEMA_TYPE, str):
+            return SchemaType(cls._SCHEMA_TYPE)
         else:
-            raise TypeError(f"Invalid schema type: {type(self._SCHEMA_TYPE)}")
+            raise TypeError(f"Invalid schema type: {type(cls._SCHEMA_TYPE)}")
 
-    @property
-    def file_name_with_extension(self) -> str:
-        return self._FILENAME + "." + self._EXTENSION
+    @classproperty
+    def file_name_with_extension(cls) -> str:
+        return cls._FILENAME + "." + cls._EXTENSION
 
-    @property
-    def datatypes(self) -> Dict[str, DataType]:
+    @classproperty
+    def datatypes(cls_or_self) -> Dict[str, DataType]:
         # Check implementation
-        if self._DATATYPES == "default_datatypes":
+        if cls_or_self._DATATYPES == "default_datatypes":
             raise NotImplementedError("_DATATYPES must be overridden by subclasses")
 
-        if self.is_multi() and self._subschema_key is not None:
-            dtypes = self._DATATYPES[self._subschema_key]  # noqa
-        elif self.is_single():
-            dtypes = self._DATATYPES
+        if cls_or_self.has_subschema_specified:
+            dtypes = cls_or_self._DATATYPES[cls_or_self._subschema_key]  # noqa
+        elif cls_or_self.is_single():
+            dtypes = cls_or_self._DATATYPES
         else:
-            raise ValueError("Method is only available for single schemas")
+            raise ValueError(
+                "Method is only available for schemas that are single or specified"
+            )
 
-        self._validate_datatypes(dtypes)
+        cls_or_self._validate_datatypes(dtypes)
 
         return dtypes
 
-    def _validate_datatypes(self, dtypes: dict[str, DataType]) -> None:
+    @classmethod
+    def _validate_datatypes(cls, dtypes: dict[str, DataType]) -> None:
         # for single schema type: the return value must be Dict[str,DataType]
         dtypes: Dict[str, DataType]
         for field, dtype in dtypes.items():
@@ -126,16 +145,16 @@ class Schema(ABC):
                 f"Datatype for field '{field}' must be a DataType, got {type(dtype)}"
             )
 
-    @property
-    def datatype_groups(self) -> Dict[str, Dict[str, DataType]]:
-        if not self.is_multi():
+    @classproperty
+    def datatype_groups(cls) -> Dict[str, Dict[str, DataType]]:
+        if not cls.is_multi():
             raise ValueError("Method is only available for multi schemas")
 
         # grab from implementation
-        if self._DATATYPES == "default_datatypes":
+        if cls._DATATYPES == "default_datatypes":
             raise NotImplementedError("_DATATYPES must be overridden by subclasses")
 
-        dtypes = self._DATATYPES
+        dtypes = cls._DATATYPES
 
         # for multi-schema type: the return value must be Dict[str,Dict[str,DataType]]
         dtypes: Dict[str, Dict[str, DataType]]
@@ -143,25 +162,18 @@ class Schema(ABC):
             assert isinstance(schema_name, str), (
                 f"Schema name must be a string, got {type(schema_name)}"
             )
-            for field, dtype in schema_datatypes.items():
-                assert isinstance(field, str), (
-                    f"Field name must be a string, got {type(field)}"
-                )
-                assert isinstance(dtype, DataType), (
-                    f"Datatype for field '{field}' must be a DataType, "
-                    f"got {type(dtype)}"
-                )
+            cls._validate_datatypes(schema_datatypes)
 
         # return
         return dtypes
 
-    @property
-    def sub_names(self) -> List[str]:
+    @classproperty
+    def sub_names(cls) -> List[str]:
         """Return the names of sub-schemas for multi-schema types."""
-        if self.schema_type == SchemaType.SINGLE:
+        if cls.schema_type == SchemaType.SINGLE:
             raise ValueError("Single-schema types do not have sub-schemas")
-        elif self.schema_type == SchemaType.MULTI:
-            return list(self.datatype_groups.keys())
+        elif cls.schema_type == SchemaType.MULTI:
+            return list(cls.datatype_groups.keys())
 
         raise ValueError("Invalid schema type")
 
@@ -196,19 +208,58 @@ class Schema(ABC):
             and not inspect.isdatadescriptor(attr)
         ]
 
-    def is_multi(self) -> bool:
+    @classmethod
+    def is_multi(cls) -> bool:
         """Check if the schema is a multi-schema type."""
-        return self.schema_type == SchemaType.MULTI
+        return cls.schema_type == SchemaType.MULTI
 
-    def is_single(self) -> bool:
+    @classproperty
+    def has_subschema_specified(cls_or_self) -> bool:
+        """
+        Check if this schema class/instance has a specific subschema selected.
+
+        For classes: Always returns False (no subschema can be specified at class level).
+        For instances of MULTI schemas: Returns True if a subschema key is set.
+        For instances of SINGLE schemas: Always returns False.
+
+        Returns:
+            bool: True if this is a MULTI schema instance with subschema key set.
+
+        """
+        # Check if it's an instance (has _subschema_key attribute from __init__)
+        if isinstance(cls_or_self, Schema):
+            return cls_or_self.is_multi() and cls_or_self._subschema_key is not None
+        # It's a class - subschema can't be specified at class level
+        return False
+
+    @classmethod
+    def is_single(cls) -> bool:
         """Check if the schema is a single-schema type."""
-        return self.schema_type == SchemaType.SINGLE
+        return cls.schema_type == SchemaType.SINGLE
 
-    def generate_subschema(self, key):
-        """Retrieve the subschema for the current schema type."""
-        if not self.is_multi():
-            raise ValueError("Cannot retrieve subschema for non-multi schema")
+    @classmethod
+    def get_subschema(cls, key: str) -> "Schema":
+        """
+        Create an instance representing a subset of a multi-schema.
 
-        assert key in self.sub_names, f"Key {key} does not define a subschema"
+        For MULTI schemas, this returns an instance that behaves as a SINGLE
+        schema containing only the columns for the specified sheet/sub-name.
 
-        return type(self)(subschema_key=key)
+        Args:
+            key: The name of the sub-schema (e.g., sheet name in XLSX)
+
+        Returns:
+            A Schema instance with datatypes filtered to the specified subset.
+
+        Raises:
+            ValueError: If called on a SINGLE schema or if key is invalid.
+        """
+        if not cls.is_multi():
+            raise ValueError("get_subschema() is only available for MULTI schemas")
+
+        if key not in cls.sub_names:
+            raise ValueError(
+                f"Key '{key}' does not define a subschema. Available: {cls.sub_names}"
+            )
+
+        return cls(subschema_key=key)

--- a/packages/algomancy-gui/src/algomancy_gui/configuration/appconfiguration.py
+++ b/packages/algomancy-gui/src/algomancy_gui/configuration/appconfiguration.py
@@ -130,7 +130,7 @@ class AppConfiguration(CoreConfiguration):
         etl_factory: Any | None = None,
         kpi_templates: Dict[str, Type[BASE_KPI]] | None = None,
         algo_templates: Dict[str, Type[ALGORITHM]] | None = None,
-        schemas: List[Schema] | None = None,
+        schemas: List[Type[Schema]] | None = None,
         # === auto start/create features ===
         autocreate: bool | None = False,
         default_algo: str | None = None,

--- a/packages/algomancy-scenario/src/algomancy_scenario/core_configuration.py
+++ b/packages/algomancy-scenario/src/algomancy_scenario/core_configuration.py
@@ -54,7 +54,7 @@ class CoreConfiguration:
         etl_factory: Any | None = None,
         kpi_templates: Dict[str, Type[BASE_KPI]] | None = None,
         algo_templates: Dict[str, Type[ALGORITHM]] | None = None,
-        schemas: List[Schema] | None = None,
+        schemas: List[Type[Schema]] | None = None,
         # === auto start/create features ===
         autocreate: bool | None = None,
         default_algo: str | None = None,

--- a/packages/algomancy-scenario/tests/conftest.py
+++ b/packages/algomancy-scenario/tests/conftest.py
@@ -52,13 +52,12 @@ class WarehouseLayoutSchema(Schema):
     Y = "y"
     ZONE = "zone"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            WarehouseLayoutSchema.ID: DataType.STRING,
-            WarehouseLayoutSchema.ZONE: DataType.STRING,
-            WarehouseLayoutSchema.X: DataType.FLOAT,
-            WarehouseLayoutSchema.Y: DataType.FLOAT,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        ZONE: DataType.STRING,
+        X: DataType.FLOAT,
+        Y: DataType.FLOAT,
+    }
 
 
 class ItemDataSchema(Schema):
@@ -78,18 +77,17 @@ class ItemDataSchema(Schema):
     CURRENT_SLOT = "currentslot"
     OPTIMAL_SLOT = "optimalslot"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            ItemDataSchema.ID: DataType.STRING,
-            ItemDataSchema.SKU: DataType.STRING,
-            ItemDataSchema.DESCRIPTION: DataType.STRING,
-            ItemDataSchema.CATEGORY: DataType.STRING,
-            ItemDataSchema.DAILY_PICKS: DataType.INTEGER,
-            ItemDataSchema.VOLUME_CM3: DataType.FLOAT,
-            ItemDataSchema.WEIGHT_KG: DataType.FLOAT,
-            ItemDataSchema.CURRENT_SLOT: DataType.STRING,
-            ItemDataSchema.OPTIMAL_SLOT: DataType.STRING,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        SKU: DataType.STRING,
+        DESCRIPTION: DataType.STRING,
+        CATEGORY: DataType.STRING,
+        DAILY_PICKS: DataType.INTEGER,
+        VOLUME_CM3: DataType.FLOAT,
+        WEIGHT_KG: DataType.FLOAT,
+        CURRENT_SLOT: DataType.STRING,
+        OPTIMAL_SLOT: DataType.STRING,
+    }
 
 
 class EmployeeDataSchema(Schema):
@@ -111,20 +109,19 @@ class EmployeeDataSchema(Schema):
     position = "attributes.position"
     skills = "attributes.skills"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            EmployeeDataSchema.ID: DataType.STRING,
-            EmployeeDataSchema.name: DataType.STRING,
-            EmployeeDataSchema.email: DataType.STRING,
-            EmployeeDataSchema.hire_date: DataType.DATETIME,
-            EmployeeDataSchema.last_login: DataType.DATETIME,
-            EmployeeDataSchema.dates_with_typo: DataType.DATETIME,
-            EmployeeDataSchema.is_active: DataType.BOOLEAN,
-            EmployeeDataSchema.age: DataType.INTEGER,
-            EmployeeDataSchema.department: DataType.STRING,
-            EmployeeDataSchema.position: DataType.STRING,
-            EmployeeDataSchema.skills: DataType.STRING,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        name: DataType.STRING,
+        email: DataType.STRING,
+        hire_date: DataType.DATETIME,
+        last_login: DataType.DATETIME,
+        dates_with_typo: DataType.DATETIME,
+        is_active: DataType.BOOLEAN,
+        age: DataType.INTEGER,
+        department: DataType.STRING,
+        position: DataType.STRING,
+        skills: DataType.STRING,
+    }
 
 
 class InventorySchema(Schema):
@@ -155,29 +152,28 @@ class InventorySchema(Schema):
     SAFETY_STOCK = "Safety\nStock"
     VALUE_BASED_ON_SAFETY_STOCK = "Value \nBased on \nSafety Stock"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            InventorySchema.BRANCH: DataType.STRING,
-            InventorySchema.LOCATION_TYPE: DataType.STRING,
-            InventorySchema.LOCATION: DataType.STRING,
-            InventorySchema.ITEM_NUMBER: DataType.STRING,
-            InventorySchema.ITEM_DESCRIPTION: DataType.STRING,
-            InventorySchema.ITEM_DESCRIPTION_2: DataType.STRING,
-            InventorySchema.LOT_SERIAL_NUMBER: DataType.STRING,
-            InventorySchema.IB_SETUP_STATUS: DataType.STRING,
-            InventorySchema.TECHNICAL_STATUS: DataType.STRING,
-            InventorySchema.STOCKING_TYPE: DataType.STRING,
-            InventorySchema.LINE_TYPE: DataType.STRING,
-            InventorySchema.MASTER_PLANNING_FAMILY: DataType.STRING,
-            InventorySchema.INVENTORY_COST_SELECTOR: DataType.STRING,
-            InventorySchema.GL_CATEGORY: DataType.STRING,
-            InventorySchema.UOM_PRIMARY: DataType.STRING,
-            InventorySchema.UNIT_COST: DataType.FLOAT,
-            InventorySchema.QUANTITY_ON_HAND: DataType.FLOAT,
-            InventorySchema.INVENTORY_VALUE: DataType.FLOAT,
-            InventorySchema.SAFETY_STOCK: DataType.FLOAT,
-            InventorySchema.VALUE_BASED_ON_SAFETY_STOCK: DataType.FLOAT,
-        }
+    _DATATYPES = {
+        BRANCH: DataType.STRING,
+        LOCATION_TYPE: DataType.STRING,
+        LOCATION: DataType.STRING,
+        ITEM_NUMBER: DataType.STRING,
+        ITEM_DESCRIPTION: DataType.STRING,
+        ITEM_DESCRIPTION_2: DataType.STRING,
+        LOT_SERIAL_NUMBER: DataType.STRING,
+        IB_SETUP_STATUS: DataType.STRING,
+        TECHNICAL_STATUS: DataType.STRING,
+        STOCKING_TYPE: DataType.STRING,
+        LINE_TYPE: DataType.STRING,
+        MASTER_PLANNING_FAMILY: DataType.STRING,
+        INVENTORY_COST_SELECTOR: DataType.STRING,
+        GL_CATEGORY: DataType.STRING,
+        UOM_PRIMARY: DataType.STRING,
+        UNIT_COST: DataType.FLOAT,
+        QUANTITY_ON_HAND: DataType.FLOAT,
+        INVENTORY_VALUE: DataType.FLOAT,
+        SAFETY_STOCK: DataType.FLOAT,
+        VALUE_BASED_ON_SAFETY_STOCK: DataType.FLOAT,
+    }
 
 
 class LocationSchema(Schema):
@@ -193,17 +189,16 @@ class LocationSchema(Schema):
     ID = "ID"
     Name = "Naam"
 
-    def _defined_datatypes(self) -> Dict[str, Dict[str, DataType]]:
-        return {
-            "Steden": {
-                LocationSchema.COUNTRY: DataType.STRING,
-                LocationSchema.CITY: DataType.STRING,
-            },
-            "Klanten": {
-                LocationSchema.ID: DataType.INTEGER,
-                LocationSchema.Name: DataType.STRING,
-            },
-        }
+    _DATATYPES = {
+        "Steden": {
+            COUNTRY: DataType.STRING,
+            CITY: DataType.STRING,
+        },
+        "Klanten": {
+            ID: DataType.INTEGER,
+            Name: DataType.STRING,
+        },
+    }
 
 
 example_schemas = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "algomancy-scenario >= 0.4.4",
   "algomancy-utils >= 0.4.4",
   "furo>=2025.12.19",
+  "ipykernel>=7.2.0",
   "myst-parser>=5.0.0",
   "pydata-sphinx-theme>=0.16.1",
   "sphinx>=9.1.0",

--- a/tutorial/src/data_handling/schemas.py
+++ b/tutorial/src/data_handling/schemas.py
@@ -1,4 +1,3 @@
-from typing import Dict
 from algomancy_data import Schema, DataType, FileExtension, SchemaType
 
 
@@ -11,12 +10,11 @@ class DCSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            DCSchema.ID: DataType.STRING,
-            DCSchema.X: DataType.INTEGER,
-            DCSchema.Y: DataType.INTEGER,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        X: DataType.INTEGER,
+        Y: DataType.INTEGER,
+    }
 
 
 class LocationSchema(Schema):
@@ -28,19 +26,18 @@ class LocationSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, Dict[str, DataType]]:
-        return {
-            "customer": {
-                LocationSchema.ID: DataType.STRING,
-                LocationSchema.X: DataType.INTEGER,
-                LocationSchema.Y: DataType.INTEGER,
-            },
-            "xdock": {
-                LocationSchema.ID: DataType.STRING,
-                LocationSchema.X: DataType.INTEGER,
-                LocationSchema.Y: DataType.INTEGER,
-            },
-        }
+    _DATATYPES = {
+        "customer": {
+            ID: DataType.STRING,
+            X: DataType.INTEGER,
+            Y: DataType.INTEGER,
+        },
+        "xdock": {
+            ID: DataType.STRING,
+            X: DataType.INTEGER,
+            Y: DataType.INTEGER,
+        },
+    }
 
 
 class StoresSchema(Schema):
@@ -52,12 +49,11 @@ class StoresSchema(Schema):
     X = "x"
     Y = "y"
 
-    def _defined_datatypes(self) -> Dict[str, DataType]:
-        return {
-            StoresSchema.ID: DataType.STRING,
-            StoresSchema.X: DataType.INTEGER,
-            StoresSchema.Y: DataType.INTEGER,
-        }
+    _DATATYPES = {
+        ID: DataType.STRING,
+        X: DataType.INTEGER,
+        Y: DataType.INTEGER,
+    }
 
 
 schemas = [

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,7 @@ dependencies = [
     { name = "algomancy-scenario" },
     { name = "algomancy-utils" },
     { name = "furo" },
+    { name = "ipykernel" },
     { name = "myst-parser" },
     { name = "pydata-sphinx-theme" },
     { name = "sphinx" },
@@ -66,6 +67,7 @@ requires-dist = [
     { name = "algomancy-scenario", editable = "packages/algomancy-scenario" },
     { name = "algomancy-utils", editable = "packages/algomancy-utils" },
     { name = "furo", specifier = ">=2025.12.19" },
+    { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "myst-parser", specifier = ">=5.0.0" },
     { name = "pydata-sphinx-theme", specifier = ">=0.16.1" },
     { name = "sphinx", specifier = ">=9.1.0" },
@@ -206,12 +208,30 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
 name = "astroid"
 version = "3.3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/74/dfb75f9ccd592bbedb175d4a32fc643cf569d7c218508bfbd6ea7ef9c091/astroid-3.3.11.tar.gz", hash = "sha256:1e5a5011af2920c7c67a53f65d536d65bfa7116feeaf2354d8b94f29573bb0ce", size = 400439, upload-time = "2025-07-13T18:04:23.177Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/0f/3b8fdc946b4d9cc8cc1e8af42c4e409468c84441b933d037e101b3d72d86/astroid-3.3.11-py3-none-any.whl", hash = "sha256:54c760ae8322ece1abd213057c4b5bba7c49818853fc901ef09719a60dbf9dec", size = 275612, upload-time = "2025-07-13T18:04:21.07Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
 ]
 
 [[package]]
@@ -252,6 +272,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -298,6 +351,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
 ]
 
 [[package]]
@@ -359,6 +421,28 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -374,6 +458,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -449,12 +542,81 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl", hash = "sha256:3bbd4420d2b3cc105cbdf3756bfc04500b1e52f090a90716851f3916c62e1661", size = 118788, upload-time = "2026-02-06T16:43:25.149Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/aa/898dec789a05731cd5a9f50605b7b44a72bd198fd0d4528e11fc610177cc/ipython-9.10.0-py3-none-any.whl", hash = "sha256:c6ab68cc23bba8c7e18e9b932797014cc61ea7fd6f19de180ab9ba73e65ee58d", size = 622774, upload-time = "2026-02-02T10:00:31.503Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
 ]
 
 [[package]]
@@ -467,6 +629,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
 ]
 
 [[package]]
@@ -509,6 +700,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
 ]
 
 [[package]]
@@ -645,6 +848,36 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -655,6 +888,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/4f/8a10a9b9f5192cb6fdef62f1d77fa7d834190b2c50c0cd256bd62879212b/plotly-6.5.2.tar.gz", hash = "sha256:7478555be0198562d1435dee4c308268187553cc15516a2f4dd034453699e393", size = 7015695, upload-time = "2026-01-14T21:26:51.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/67/f95b5460f127840310d2187f916cf0023b5875c0717fdf893f71e1325e87/plotly-6.5.2-py3-none-any.whl", hash = "sha256:91757653bd9c550eeea2fa2404dba6b85d1e366d54804c340b2c874e5a7eb4a4", size = 9895973, upload-time = "2026-01-14T21:26:47.135Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -729,6 +1023,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
 ]
 
 [[package]]
@@ -989,6 +1314,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1007,6 +1346,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/85/ad/430fb60d90e1d112a62ff57bdd1f286ec73a2a0331272febfddd21f330e1/StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff", size = 23384, upload-time = "2023-06-29T22:02:58.399Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/69/297302c5f5f59c862faa31e6cb9a4cd74721cd1e052b38e464c5b402df8b/StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659", size = 8851, upload-time = "2023-06-29T22:02:56.947Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/1d/0a336abf618272d53f62ebe274f712e213f5a03c0b2339575430b8362ef2/tornado-6.5.4.tar.gz", hash = "sha256:a22fa9047405d03260b483980635f0b041989d8bcc9a313f8fe18b411d84b1d7", size = 513632, upload-time = "2025-12-15T19:21:03.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/a9/e94a9d5224107d7ce3cc1fab8d5dc97f5ea351ccc6322ee4fb661da94e35/tornado-6.5.4-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d6241c1a16b1c9e4cc28148b1cda97dd1c6cb4fb7068ac1bedc610768dff0ba9", size = 443909, upload-time = "2025-12-15T19:20:48.382Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7e/f7b8d8c4453f305a51f80dbb49014257bb7d28ccb4bbb8dd328ea995ecad/tornado-6.5.4-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2d50f63dda1d2cac3ae1fa23d254e16b5e38153758470e9956cbc3d813d40843", size = 442163, upload-time = "2025-12-15T19:20:49.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b5/206f82d51e1bfa940ba366a8d2f83904b15942c45a78dd978b599870ab44/tornado-6.5.4-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1cf66105dc6acb5af613c054955b8137e34a03698aa53272dbda4afe252be17", size = 445746, upload-time = "2025-12-15T19:20:51.491Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9d/1a3338e0bd30ada6ad4356c13a0a6c35fbc859063fa7eddb309183364ac1/tornado-6.5.4-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50ff0a58b0dc97939d29da29cd624da010e7f804746621c78d14b80238669335", size = 445083, upload-time = "2025-12-15T19:20:52.778Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d4/e51d52047e7eb9a582da59f32125d17c0482d065afd5d3bc435ff2120dc5/tornado-6.5.4-cp39-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fb5e04efa54cf0baabdd10061eb4148e0be137166146fff835745f59ab9f7f", size = 445315, upload-time = "2025-12-15T19:20:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/27/07/2273972f69ca63dbc139694a3fc4684edec3ea3f9efabf77ed32483b875c/tornado-6.5.4-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9c86b1643b33a4cd415f8d0fe53045f913bf07b4a3ef646b735a6a86047dda84", size = 446003, upload-time = "2025-12-15T19:20:56.101Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/83/41c52e47502bf7260044413b6770d1a48dda2f0246f95ee1384a3cd9c44a/tornado-6.5.4-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:6eb82872335a53dd063a4f10917b3efd28270b56a33db69009606a0312660a6f", size = 445412, upload-time = "2025-12-15T19:20:57.398Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/bc96917f06cbee182d44735d4ecde9c432e25b84f4c2086143013e7b9e52/tornado-6.5.4-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6076d5dda368c9328ff41ab5d9dd3608e695e8225d1cd0fd1e006f05da3635a8", size = 445392, upload-time = "2025-12-15T19:20:58.692Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/1a/d7592328d037d36f2d2462f4bc1fbb383eec9278bc786c1b111cbbd44cfa/tornado-6.5.4-cp39-abi3-win32.whl", hash = "sha256:1768110f2411d5cd281bac0a090f707223ce77fd110424361092859e089b38d1", size = 446481, upload-time = "2025-12-15T19:21:00.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6d/c69be695a0a64fd37a97db12355a035a6d90f79067a3cf936ec2b1dc38cd/tornado-6.5.4-cp39-abi3-win_amd64.whl", hash = "sha256:fa07d31e0cd85c60713f2b995da613588aa03e1303d75705dca6af8babc18ddc", size = 446886, upload-time = "2025-12-15T19:21:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/50/49/8dc3fd90902f70084bd2cd059d576ddb4f8bb44c2c7c0e33a11422acb17e/tornado-6.5.4-cp39-abi3-win_arm64.whl", hash = "sha256:053e6e16701eb6cbe641f308f4c1a9541f91b6261991160391bfc342e8a551a1", size = 445910, upload-time = "2025-12-15T19:21:02.571Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
 ]
 
 [[package]]
@@ -1090,6 +1457,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Further refinement of schema classes: datatypes are now stored in the class variable _DATATYPES such that the Schemas no longer need to be instantiated before being passed to the configuration. 

Passing instances still works. 