### PR TITLE
M12 follow-up: dedupe null-handling, quickstart invocation, paginated milestone lookup

### DIFF
--- a/.github/workflows/release_checklist.yml
+++ b/.github/workflows/release_checklist.yml
@@ -52,15 +52,19 @@ jobs:
           # Both triggers (workflow_run and push:tags) can fire for the same
           # release; bail out cleanly if an issue for this milestone already
           # exists rather than opening duplicates.
-          EXISTING=$(gh issue list \
+          # `.[0] // empty` emits the first match if any, or nothing at all
+          # when the array is empty — without this jq prints the literal
+          # string "null", which would slip past `[ -n "$EXISTING" ]` and
+          # crash the python parser. `2>/dev/null || true` swallows the
+          # "milestone not found" error gh emits on the very first release.
+          EXISTING_URL=$(gh issue list \
             --label release-checklist \
             --milestone "$TITLE" \
             --state all \
-            --json number,url \
-            --jq '.[0]' || echo '')
-          if [ -n "$EXISTING" ]; then
-            URL=$(echo "$EXISTING" | python -c "import json,sys;print(json.load(sys.stdin)['url'])")
-            echo "release-checklist issue already exists for $TITLE: $URL"
+            --json url \
+            --jq '.[0].url // empty' 2>/dev/null || true)
+          if [ -n "$EXISTING_URL" ]; then
+            echo "release-checklist issue already exists for $TITLE: $EXISTING_URL"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -82,7 +86,10 @@ jobs:
           TITLE="${{ steps.version.outputs.title }}"
           # `state=all` so a previously-closed milestone with the same name
           # is reused instead of triggering a duplicate-create 422.
-          EXISTING=$(gh api 'repos/:owner/:repo/milestones?state=all' \
+          # `--paginate` so we still find older milestones once the repo has
+          # more than the default page (30) of them.
+          EXISTING=$(gh api --paginate \
+            'repos/:owner/:repo/milestones?state=all&per_page=100' \
             --jq ".[] | select(.title == \"$TITLE\") | .number" | head -n1)
           if [ -z "$EXISTING" ]; then
             gh api repos/:owner/:repo/milestones \

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -78,9 +78,13 @@
 
 For at least the combos `(backend=json, interface=gui)` and `(backend=database, interface=api)`:
 
-- [ ] From `<tmp>`: `uv run --from <repo> algomancy-quickstart` (or `python -m algomancy_quickstart` if invoked from inside the repo) — run the wizard and answer prompts
-- [ ] `python main.py --validate` exits 0 from inside the generated project directory (`<tmp>/<project-name>/`)
-- [ ] `uv run pytest tests/` from inside the generated project exits 0
+- [ ] From `<tmp>`, invoke the wizard using the console script installed in `<repo>`'s venv. Pick the form that fits your shell:
+      - POSIX: `<repo>/.venv/bin/algomancy-quickstart`
+      - Windows: `<repo>\.venv\Scripts\algomancy-quickstart.exe`
+      - Or activate the venv first (`source <repo>/.venv/bin/activate`) and run `algomancy-quickstart` directly.
+- [ ] Answer the wizard prompts; it writes the generated project into `<tmp>/<project-name>/`.
+- [ ] `cd <tmp>/<project-name> && python main.py --validate` exits 0.
+- [ ] `cd <tmp>/<project-name> && uv run pytest tests/` exits 0.
 
 ## 7 Docs
 

--- a/algomancy-version-bump.py
+++ b/algomancy-version-bump.py
@@ -52,8 +52,6 @@ def check_version_consistency() -> int:
     1 if any file is unreadable, missing, or disagrees — failures are listed
     individually so the CI log points at the file to fix.
     """
-    import tomllib
-
     root_pyproject = Path("pyproject.toml")
     packages_dir = Path("packages")
 


### PR DESCRIPTION
## Summary

Follow-up to PR #165. Fixes two real bugs and one minor cleanup that I flagged in the post-merge review.

- **`release_checklist.yml` dedupe**: replaced `--jq '.[0]'` with `--jq '.[0].url // empty'`. The previous form printed the literal string `null` when the issue list was empty; that string slipped past `[ -n "$EXISTING" ]` and crashed the python sub-shell with `TypeError: 'NoneType' object is not subscriptable`. Path-of-failure: a previous run created the milestone but failed before opening the issue (transient API error) — the next trigger would then hit this branch every time. Also dropped the now-unused python JSON-parse sub-shell; the URL comes straight out of jq.
- **`release_checklist.yml` milestone lookup**: added `--paginate` + `per_page=100` to the `gh api 'repos/:owner/:repo/milestones?state=all'` call. Without paginate, the lookup misses closed milestones once the repo accumulates >30 — at which point the workflow starts creating duplicate milestones for every release.
- **`RELEASE_CHECKLIST.md` §6**: the previous `uv run --from <repo> algomancy-quickstart` is invalid — `uv run --from` takes a package specifier, not a repo path. Replaced with three concrete shell-specific invocations (POSIX path, Windows path, activated-venv) so a tester can pick the form that fits their setup.
- **`algomancy-version-bump.py`**: dropped a redundant `import tomllib` inside `check_version_consistency` (already imported at module top).

## Test plan

- [x] `uv run python algomancy-version-bump.py --check` exits 0 (`[OK] All 9 pyproject.toml files agree on version 0.7.0`).
- [x] `yaml.safe_load(open('.github/workflows/release_checklist.yml'))` parses.
- [x] Dedupe `null` repro: `echo '[]' | jq '.[0] // empty'` → empty (was `null`); `[ -n "" ]` is false.
- [x] pre-commit (`ruff format` + `ruff check`) passes.

The release_checklist workflow itself only fires on a real publish or tag push, so end-to-end exercise will happen organically on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)