### PR TITLE
Json multi wrapup

### DIFF
--- a/docs/source/getting_started/quickstart.md
+++ b/docs/source/getting_started/quickstart.md
@@ -69,24 +69,33 @@ algomancy-quickstart
 to be guided through the set-up steps, outlined below. 
 1. **Creating the folder structure**
     
-    The user is prompted for some basic information (app title, host, port), after which the following directory
-    structure is created, with a basic `main.py` file.
+    The user is prompted for some basic information (app title, host, port, interface, persistence backend), after which
+    the following directory structure is created, with a basic `main.py` file.
+
+    The **interface** prompt accepts a comma-separated subset of `gui` and `api` (e.g. `gui`, `api`, or `gui,api`). GUI-only
+    artifacts are skipped when `gui` is not selected — an API-only project will not contain `assets/`, `src/pages/`, or
+    `src/styling_config.py`, and steps 4 (default assets) and 5 (styling) are skipped without prompting. The persistence
+    backend is one of `none`, `json`, or `database` and is wired into `CoreConfig` in the generated `main.py`.
+
     :::{dropdown} {octicon}`code` Content after step
     :color: secondary
     ```{code-block} text
-    :caption: Project directory after initializing with algomancy-quickstart
+    :caption: Project directory after initializing with algomancy-quickstart (GUI interface)
     root/
-    |── assets/ 
+    |── assets/                  # GUI only
     ├── data/   
     │   └── setup/
     ├── src/
     │   ├── data_handling/
-    │   ├── pages/
+    │   ├── pages/               # GUI only
     │   └── templates/
     │       ├── kpi/
     │       └── algorithm/
     └── main.py  
     ```
+
+    For an API-only project (`interfaces=api`), the `assets/` and `src/pages/` folders are not created.
+
     ```{code-block} python
     :linenos:
     :caption: main.py after initializing with algomancy-quickstart
@@ -172,9 +181,9 @@ to be guided through the set-up steps, outlined below.
     :::{dropdown} {octicon}`code` Content after step
     :color: secondary
     ```{code-block} text
-    :caption: Project directory after algomancy-quickstart
+    :caption: Project directory after algomancy-quickstart (GUI interface)
     root/
-    |── assets/ 
+    |── assets/                       # GUI only
     │   ├── css/
     │   ├── ...
     │   └── styling.css
@@ -185,7 +194,7 @@ to be guided through the set-up steps, outlined below.
     │   ├── data_handling/
     │   │   ├── etl_factory.py
     │   │   └── generated_schemas.py
-    │   ├── pages/
+    │   ├── pages/                    # GUI only
     │   │   ├── compare_page.py
     │   │   ├── data_page.py
     │   │   ├── home_page.py
@@ -196,7 +205,7 @@ to be guided through the set-up steps, outlined below.
     │   │   │   └── custom_kpi.py
     │   │   └── algorithm/
     │   │       └── custom_algorithm.py
-    │   └── styling_config.py
+    │   └── styling_config.py         # GUI only
     └── main.py  
     ```
     ```{code-block} python

--- a/docs/source/reference/api.md
+++ b/docs/source/reference/api.md
@@ -167,18 +167,131 @@ should poll `/status` for progress.
 | `GET` | `/sessions/{sid}/scenarios/{id}/status` | Lightweight `{id, tag, status, progress}` for polling |
 | `GET` | `/sessions/{sid}/processing` | The scenario currently processing, or `null` |
 
-Status codes for `POST /scenarios`:
-- `201` on success.
-- `404` if `algo_name` or `dataset_key` does not exist in this session.
-- `409` if `tag` is already used.
-- `400` for parameter validation failures (out-of-range values, wrong types).
-- `422` if a required body field is missing (Pydantic-level validation).
-
 ```{tip}
 The `/status` endpoint is intentionally small: just id, tag, status, and
 progress. It is safe to poll at a high frequency without serializing the full
 scenario (with KPIs, algorithm config, and result payload) every time.
 ```
+
+(api-create-scenario-ref)=
+### `POST /sessions/{sid}/scenarios` — create a scenario
+
+Binds an input dataset + algorithm + parameter values into a runnable
+scenario. The body is JSON.
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `tag` | string | yes | Human-readable scenario name. Must be unique within the session — duplicates return `409`. |
+| `dataset_key` | string | yes | Must exist in this session's data manager. Discover via `GET /data`. |
+| `algo_name` | string | yes | Must exist in `available_algorithms`. Discover via `GET /algorithms`. |
+| `algo_params` | object | no | Parameter values keyed by parameter name. Omit or set to `null` for defaults. Discover the expected keys via `GET /algorithms/{name}/parameters`. |
+
+The `algo_params` keys come from the algorithm's parameter set — the
+`/parameters` endpoint described above returns the schema. Values are
+validated against that schema by `BaseParameterSet`; bad values raise
+`ParameterError` and the route returns `400` with the detail.
+
+**Example**
+
+```{code-block} python
+import httpx
+
+scenario = httpx.post(
+    "http://127.0.0.1:8051/api/v1/sessions/main/scenarios",
+    json={
+        "tag": "slow-5s",
+        "dataset_key": "Master data",
+        "algo_name": "Slow",
+        "algo_params": {"duration": 5},
+    },
+).json()
+```
+
+**Response** (`201`)
+
+Returns the full `Scenario.to_dict()` payload (see
+{ref}`Scenario response shape <api-scenario-shape-ref>` below). At this point
+`status` is `"CREATED"`, `result` is `null`, and each KPI's `value` is `None`.
+
+**Error cases**
+
+| Status | When |
+|---|---|
+| `404` | `algo_name` is not registered, or `dataset_key` is not present. |
+| `409` | `tag` already exists in this session. |
+| `400` | A parameter value failed validation (`ParameterError`). |
+| `422` | A required field is missing or has the wrong JSON type (Pydantic-level). |
+
+(api-run-scenario-ref)=
+### `POST /sessions/{sid}/scenarios/{id}/run` — enqueue for processing
+
+Fire-and-forget. Returns `202 Accepted` immediately and returns the scenario
+in its `QUEUED` state — actual computation happens on a worker thread. Clients
+must poll `GET /status` to observe progress and completion.
+
+The status state machine, in order:
+
+```
+CREATED  →  QUEUED  →  PROCESSING  →  COMPLETE
+                                  ↘   FAILED
+```
+
+`COMPLETE` and `FAILED` are terminal. A subsequent `/run` on a terminal
+scenario re-enqueues it from the current state — the manager allows re-runs.
+At any moment, at most one scenario per session is in `PROCESSING`; check
+`GET /processing` to see which one.
+
+**Polling**
+
+`GET /status` returns just `{id, tag, status, progress}` and is safe to call
+at high frequency. `progress` is a float in `[0.0, 1.0]`. Once `status` is
+`COMPLETE` or `FAILED`, fetch the full result with `GET /scenarios/{id}`.
+
+**Error cases**
+
+| Status | When |
+|---|---|
+| `404` | `scenario_id` does not exist in this session. |
+| `500` | The algorithm raised an exception during processing. Note: the HTTP response for `/run` itself does not surface this — the failure is reflected in the scenario's `status=FAILED` field. Inspect the server log for the traceback. |
+
+(api-scenario-shape-ref)=
+### Scenario response shape
+
+`GET /scenarios` and `GET /scenarios/{id}` (and the create/run endpoints)
+return the dict produced by `Scenario.to_dict()`:
+
+```{code-block} json
+{
+  "id": "01HZX...",
+  "tag": "slow-5s",
+  "input_data_id": "Master data",
+  "algorithm": {
+    "name": "Slow",
+    "parameters": [
+      {"name": "duration", "type": "integer", "value": 5, "default": 1, "min": 1, "max": 60, "required": true}
+    ]
+  },
+  "kpis": {
+    "throughput": {"name": "throughput", "value": 42.0, "unit": "items/s"}
+  },
+  "status": "complete",
+  "result": { "...domain-specific Result.to_dict() payload..." }
+}
+```
+
+- `result` and each KPI's `value` are `null` until the scenario reaches
+  `COMPLETE`.
+- `kpis` is keyed by the KPI template name registered in `kpi_templates`.
+- `algorithm.parameters` is the same descriptor shape returned by
+  `GET /algorithms/{name}/parameters`, plus the `value` chosen for this run.
+- `result` is whatever your domain's `BaseResult.to_dict()` returns. The
+  framework does not impose a shape — see the
+  {ref}`Scenario reference <scenario-package-ref>`.
+
+There is no separate `/kpi-measurements` endpoint; KPI values are part of
+this payload.
 
 ## Data management
 
@@ -191,13 +304,106 @@ scenario (with KPIs, algorithm config, and result payload) every time.
 | `POST` | `/sessions/{sid}/data/from-json` | Add a dataset from a `DataSource.to_json()` payload |
 | `POST` | `/sessions/{sid}/etl` | Run ETL over an uploaded multipart bundle |
 
-`POST /etl` accepts a multipart form with `dataset_name` (form field) and one
-or more `files` parts. The filename stem becomes the logical name the ETL
-factory expects (`sku_data.csv` ⇒ `sku_data`); the extension picks the
-`File` subclass (`.csv`, `.json`, `.xlsx`).
-
 Deleting a dataset that is referenced by a scenario returns `409`. To delete
 the underlying data, delete its referencing scenarios first.
+
+(api-etl-ref)=
+### `POST /sessions/{sid}/etl` — run ETL over uploaded files
+
+Stages a bundle of uploaded files into a temp directory, wraps each one in the
+appropriate `algomancy_data.File` subclass, and calls
+`ScenarioManager.etl_data(file_map, dataset_name)`. The result is a new (or
+overwritten) dataset accessible under the chosen `dataset_name`.
+
+This is the only endpoint that uses a **multipart/form-data** body — every
+other write accepts JSON. There is no Pydantic model for the request because
+FastAPI's `UploadFile` handling is what converts the multipart parts into
+file-like objects on the server. The OpenAPI schema at `/openapi.json` does
+describe the `dataset_name` form field and the `files` array.
+
+**Form fields**
+
+| Field | Repeated? | Type | Notes |
+|---|---|---|---|
+| `dataset_name` | once | string | Logical key the resulting dataset is stored under. Required, non-empty. |
+| `files` | one or more | file upload | Each upload's filename stem becomes the **logical name** the ETL factory expects. Extension picks the `File` subclass — `csv` → `CSVFile`, `json` → `JSONFile`, `xlsx` → `XLSXFile`. Any other extension fails with `400`. |
+
+The filename stem mapping means the ETL factory does NOT receive uploaded
+filenames as opaque blobs — they must match the logical names declared by your
+schemas. For example, if your schemas declare a `sku_data` group, the
+corresponding upload must be `sku_data.csv` (or `.json`, or `.xlsx`).
+
+**Curl example**
+
+```{code-block} bash
+curl -X POST http://127.0.0.1:8051/api/v1/sessions/main/etl \
+  -F dataset_name=uploaded \
+  -F files=@./sku_data.csv \
+  -F files=@./inventory.xlsx
+```
+
+Note: each `-F files=@...` repeats the same form field name `files`; that is
+how multipart "array" fields are encoded.
+
+**Python example (httpx)**
+
+```{code-block} python
+import httpx
+
+with open("sku_data.csv", "rb") as csv, open("inventory.xlsx", "rb") as xlsx:
+    r = httpx.post(
+        "http://127.0.0.1:8051/api/v1/sessions/main/etl",
+        data={"dataset_name": "uploaded"},
+        files=[
+            ("files", ("sku_data.csv", csv, "text/csv")),
+            (
+                "files",
+                (
+                    "inventory.xlsx",
+                    xlsx,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                ),
+            ),
+        ],
+    )
+r.raise_for_status()
+```
+
+**Response**
+
+```{code-block} json
+{
+  "dataset_name": "uploaded",
+  "success": true,
+  "keys": ["uploaded", "Master data"]
+}
+```
+
+`success` reflects `ETLResult.is_success` — a successful HTTP request can
+still report `success=false` when extraction or validation produced ERRORs but
+the request itself completed cleanly. Inspect the dataset and the manager's
+log to diagnose.
+
+**Error cases**
+
+| Status | When |
+|---|---|
+| `400` | No files uploaded, an upload is missing a filename, or the filename extension is not in `{csv, json, xlsx}`. |
+| `404` | `session_id` does not exist. |
+| `422` | `dataset_name` form field missing (Pydantic-level validation). |
+| `500` | The ETL pipeline itself raised an unhandled exception (logged with traceback). |
+
+(api-from-json-ref)=
+### `POST /sessions/{sid}/data/from-json` — ingest a serialized DataSource
+
+Accepts the raw JSON produced by `DataSource.to_json()` as the request body
+(not wrapped in any envelope). The framework parses the body with
+`DataSource.from_json`, so the bytes are forwarded verbatim and the route does
+no re-encoding. Both an object-rooted and array-rooted payload are accepted —
+whichever your `DataSource` subclass produces.
+
+Returns `201` with the full key list. Common errors: `400` on an empty body or
+malformed JSON, `404` on unknown session.
 
 ## Polling pattern
 

--- a/packages/algomancy-data/src/algomancy_data/etl.py
+++ b/packages/algomancy-data/src/algomancy_data/etl.py
@@ -329,15 +329,17 @@ class ETLFactory(ABC):
         """Default validation sequence using the new built-in validators.
 
         Includes (in order): ``RequiredColumnsValidator``, ``SchemaValidator``,
-        and — when any schema declares a primary key — ``PrimaryKeyValidator``.
-        Subclasses can override to add domain-specific validators.
+        and ``PrimaryKeyValidator``. The PK validator skips schemas with no
+        declared primary key internally (and decomposes MULTI schemas into
+        per-group synthetic SINGLE schemas via ``_schema_table_map``), so it
+        is safe to append unconditionally. Subclasses can override to add
+        domain-specific validators.
         """
         validators: List[Validator] = [
             RequiredColumnsValidator(self.schemas),
             SchemaValidator(self.schemas),
+            PrimaryKeyValidator(self.schemas),
         ]
-        if any(schema.primary_key() for schema in self.schemas):
-            validators.append(PrimaryKeyValidator(self.schemas))
         return ValidationSequence(validators, logger=self.logger)
 
     def create_transformation_sequence(self) -> TransformationSequence:

--- a/packages/algomancy-data/src/algomancy_data/schema.py
+++ b/packages/algomancy-data/src/algomancy_data/schema.py
@@ -293,6 +293,10 @@ class Schema(ABC):
                 grp.name: {col.name: col for col in grp.columns} for grp in group_attrs
             }
 
+        return cls._get_legacy_column_groups_with_warning()
+
+    @classmethod
+    def _get_legacy_column_groups_with_warning(cls) -> dict[str, dict[Any, Column]]:
         if cls._DATATYPES == "default_datatypes":
             raise NotImplementedError(
                 f"{cls.__name__} must declare ColumnGroup attributes or override _DATATYPES"
@@ -305,13 +309,14 @@ class Schema(ABC):
             DeprecationWarning,
             stacklevel=2,
         )
-        return {
+        cg = {
             group_name: {
                 col_name: Column(name=col_name, dtype=dtype)
                 for col_name, dtype in sub_dict.items()
             }
             for group_name, sub_dict in cls._DATATYPES.items()
         }
+        return cg
 
     @classmethod
     def required_columns(cls) -> List[str]:

--- a/packages/algomancy-data/src/algomancy_data/schema.py
+++ b/packages/algomancy-data/src/algomancy_data/schema.py
@@ -232,14 +232,6 @@ class Schema(ABC):
                 are defined.
             TypeError: If called on a MULTI schema (use ``datatype_groups()``).
         """
-        col_attrs = [attr for attr in vars(cls).values() if isinstance(attr, Column)]
-        if col_attrs:
-            return {col.name: col for col in col_attrs}
-
-        if cls._DATATYPES == "default_datatypes":
-            raise NotImplementedError(
-                f"{cls.__name__} must declare Column attributes or override _DATATYPES"
-            )
 
         if not cls.is_single():
             raise TypeError(
@@ -247,10 +239,19 @@ class Schema(ABC):
                 "Use datatype_groups() to inspect its column groups."
             )
 
+        col_attrs = [attr for attr in vars(cls).values() if isinstance(attr, Column)]
+        if col_attrs:
+            return {col.name: col for col in col_attrs}
+
         return cls.get_legacy_columns_with_warning()
 
     @classmethod
     def get_legacy_columns_with_warning(cls) -> dict[str, Column]:
+        if cls._DATATYPES == "default_datatypes":
+            raise NotImplementedError(
+                f"{cls.__name__} must declare Column attributes or override _DATATYPES"
+            )
+
         warnings.warn(
             f"{cls.__name__} uses the legacy _DATATYPES dict. "
             "Declare Column instances as class attributes instead "

--- a/packages/algomancy-data/tests/test_disk_etl_fixtures.py
+++ b/packages/algomancy-data/tests/test_disk_etl_fixtures.py
@@ -195,6 +195,47 @@ class TestPicksJSONMultiOnDisk:
         assert child["PickLoadCarrierIdentity"].notna().all()
 
 
+class TestPicksJSONMultiOnDiskFullETL:
+    """Regression for issue #172: a ColumnGroup-only MULTI schema must
+    survive the full ``SimpleETLFactory.build_pipeline().run()`` path,
+    not just direct ``JSONMultiExtractor`` extraction. The previous gate
+    in ``ETLFactory.create_validation_sequence`` called ``primary_key()``
+    on every schema before construction, which raises on MULTI schemas
+    because ``columns()`` is SINGLE-only.
+    """
+
+    def _files(self):
+        return {
+            "picks": JSONFile(
+                name="picks", path=str(FIXTURES / "picks_json_multi" / "picks.json")
+            )
+        }
+
+    def test_validation_sequence_constructs_for_multi_schema(self):
+        # Before the #172 fix, this call raised because the gate at
+        # ``etl.py:339`` invoked ``schema.primary_key()`` on a MULTI schema,
+        # which delegates to the SINGLE-only ``columns()`` accessor.
+        factory = SimpleETLFactory(schemas=[PickLoadCarrierSchema])
+        v_seq = factory.create_validation_sequence()
+        # Construction succeeded; PK validation should now run without error
+        # against an empty data dict (no tables → no per-row checks fire).
+        result = v_seq.run_validation({})
+        assert result.is_valid
+
+    def test_full_pipeline_run_succeeds(self):
+        factory = SimpleETLFactory(schemas=[PickLoadCarrierSchema])
+        result = factory.build_pipeline("picks", self._files()).run()
+
+        assert result.is_success, [m.message for m in result.messages]
+
+        parent = result.datasource.get_table("picks.PickLoadCarriers")
+        child = result.datasource.get_table("picks.PickOrderLines")
+
+        assert len(parent) == 3
+        assert len(child) == int(parent["NumberOfPickOrderLines"].sum())
+        assert child["PickLoadCarrierIdentity"].notna().all()
+
+
 # ====================================================================== #
 # Multisheet XLSX on disk — two ColumnGroups, two sheets
 # ====================================================================== #

--- a/packages/algomancy-data/tests/test_m4.py
+++ b/packages/algomancy-data/tests/test_m4.py
@@ -157,15 +157,23 @@ class TestDefaultValidationSequence:
         assert RequiredColumnsValidator in v_types
         assert SchemaValidator in v_types
 
-    def test_pk_validator_added_when_pk_declared(self):
-        factory = SimpleETLFactory([WidgetSchema])
-        seq = factory.create_validation_sequence()
-        assert PrimaryKeyValidator in [type(v) for v in seq._validators]
+    def test_pk_validator_always_present(self):
+        # Per issue #172: the validator is now appended unconditionally so
+        # MULTI schemas (whose primary_key() raises TypeError) don't break
+        # construction. PrimaryKeyValidator self-skips per-table when no
+        # PK is declared, so its presence is harmless for NoPK schemas.
+        for schema in (WidgetSchema, NoPKSchema):
+            seq = SimpleETLFactory([schema]).create_validation_sequence()
+            assert PrimaryKeyValidator in [type(v) for v in seq._validators]
 
-    def test_pk_validator_skipped_when_no_pk(self):
-        factory = SimpleETLFactory([NoPKSchema])
-        seq = factory.create_validation_sequence()
-        assert PrimaryKeyValidator not in [type(v) for v in seq._validators]
+    def test_pk_validator_self_skips_when_no_pk(self):
+        # NoPKSchema has no primary_key declared. Running validation against
+        # an empty data dict should produce no PK-related messages — the
+        # validator iterates _schema_table_map and short-circuits per table.
+        seq = SimpleETLFactory([NoPKSchema]).create_validation_sequence()
+        result = seq.run_validation({})
+        assert all(m.code != "MISSING_PK_COLUMN" for m in result.messages)
+        assert all(m.code != "PK_NULL" for m in result.messages)
 
 
 # ------------------------------------------------------------------ #

--- a/packages/algomancy-data/tests/test_schema.py
+++ b/packages/algomancy-data/tests/test_schema.py
@@ -236,6 +236,12 @@ class TestAccessors:
 
         assert NoPK.primary_key() == ()
 
+    def test_primary_key_multi_schema_raises(self):
+        # primary_key() delegates to columns(), which is SINGLE-only by
+        # design. The TypeError surfaces from the columns() guard.
+        with pytest.raises(TypeError, match="MULTI schema"):
+            ModernMultiSchema.primary_key()
+
 
 # ------------------------------------------------------------------ #
 # datatypes() classmethod (#76)

--- a/packages/algomancy-quickstart/src/algomancy_quickstart/quickstart.py
+++ b/packages/algomancy-quickstart/src/algomancy_quickstart/quickstart.py
@@ -63,16 +63,23 @@ class QuickstartWizard:
 
         click.echo()
 
-        # Step 2: Generate custom implementation shells (optional)
+        # Step 2: Generate custom implementation shells (optional). The
+        # ``has_custom_implementations`` flag is set BEFORE the step so the
+        # ``_update_main_py_with_custom_implementations`` call inside step 2
+        # renders the right wiring on the first try (previously the flag
+        # was set after the step, and the placeholder main.py only got
+        # corrected when a later step re-rendered).
         if click.confirm(
             "Do you want to generate custom implementation templates?", default=True
         ):
-            self.step_2_generate_implementations()
             self.has_custom_implementations = True
+            self.step_2_generate_implementations()
 
         click.echo()
 
-        # Step 3: Scan data folder and generate ETL pipeline (optional)
+        # Step 3: Scan data folder and generate ETL pipeline (optional).
+        # Same pre-set-the-flag pattern as step 2: render with the right
+        # ``has_generated_etl`` value the first time around.
         if click.confirm(
             "Do you want to scan your data folder and generate an ETL pipeline?",
             default=True,
@@ -83,21 +90,27 @@ class QuickstartWizard:
 
         click.echo()
 
-        # Step 4: Install assets (optional)
-        if click.confirm(
-            "Do you want to install default assets (CSS, images)?", default=True
-        ):
-            self.step_4_install_assets()
+        # Steps 4 (assets) and 5 (styling) are GUI-only — the API launcher
+        # never reads them. Skip the prompts entirely when GUI is not in the
+        # selected interfaces, so an API-only project doesn't end up with
+        # orphaned ``assets/`` content or ``src/styling_config.py``.
+        if "gui" in self.interfaces:
+            # Step 4: Install assets (optional)
+            if click.confirm(
+                "Do you want to install default assets (CSS, images)?", default=True
+            ):
+                self.step_4_install_assets()
 
-        click.echo()
+            click.echo()
 
-        # Step 5: Configure styling (optional)
-        if click.confirm(
-            "Do you want to configure custom styling (colors, themes)?", default=True
-        ):
-            self.step_5_configure_styling()
+            # Step 5: Configure styling (optional)
+            if click.confirm(
+                "Do you want to configure custom styling (colors, themes)?",
+                default=True,
+            ):
+                self.step_5_configure_styling()
 
-        click.echo()
+            click.echo()
 
         # Step 6: Generate pytest skeletons (optional)
         if click.confirm(
@@ -161,18 +174,21 @@ class QuickstartWizard:
         # Ask which persistence backend to bake into CoreConfig.
         self.persistence_backend, self.database_url = self._prompt_persistence()
 
-        # Define folder structure - include data/setup and src/styling
+        # Define folder structure. ``assets/`` and ``src/pages/`` are
+        # GUI-only — emit them only when the user opted into the GUI
+        # interface. ``data/setup/`` stays unconditional: the ETL pipeline
+        # still reads from it for API-only projects.
         folders = [
-            "assets",
             "data",
             "data/setup",
             "src",
             "src/data_handling",
-            "src/pages",
             "src/templates",
             "src/templates/kpi",
             "src/templates/algorithm",
         ]
+        if "gui" in self.interfaces:
+            folders = ["assets", *folders, "src/pages"]
 
         # Check if any folders already exist
         existing_folders = [f for f in folders if (self.current_dir / f).exists()]
@@ -255,18 +271,25 @@ class QuickstartWizard:
         click.echo(f"Using filename: {self.filename}")
         click.echo()
 
-        # Generate each component
+        # Generate each component. Page templates are GUI-only — for an
+        # API-only project the generated ``main.py`` doesn't import them, so
+        # emitting them just leaves orphans on disk (#170).
         components = [
             ("schema", "src/data_handling", "schemas.py"),
             ("algorithm", "src/templates/algorithm", f"{self.filename}_algorithm.py"),
             ("kpi", "src/templates/kpi", f"{self.filename}_kpi.py"),
             ("etl_factory", "src/data_handling", "etl_factory.py"),
-            ("home_page", "src/pages", "home_page.py"),
-            ("data_page", "src/pages", "data_page.py"),
-            ("scenario_page", "src/pages", "scenario_page.py"),
-            ("compare_page", "src/pages", "compare_page.py"),
-            ("overview_page", "src/pages", "overview_page.py"),
         ]
+        if "gui" in self.interfaces:
+            components.extend(
+                [
+                    ("home_page", "src/pages", "home_page.py"),
+                    ("data_page", "src/pages", "data_page.py"),
+                    ("scenario_page", "src/pages", "scenario_page.py"),
+                    ("compare_page", "src/pages", "compare_page.py"),
+                    ("overview_page", "src/pages", "overview_page.py"),
+                ]
+            )
 
         click.echo("Generating implementation templates...")
 
@@ -599,14 +622,22 @@ class QuickstartWizard:
         self._render_main_py()
 
     def _display_inferred_schemas_summary(self):
-        """Display a summary of all inferred schemas."""
+        """Display a summary of all inferred schemas.
+
+        For ``SchemaType.MULTI`` files (XLSX-multi or nested-JSON), each
+        group is rendered as its own section with ``source_path``,
+        primary-key, and foreign-key annotations so the user can see the
+        structure that will end up in the generated schema file.
+        """
         click.echo(click.style("Summary of detected schemas:", fg="cyan", bold=True))
         click.echo()
 
         for file_info in self.detected_files:
+            type_label = "MULTI" if file_info.is_multi_table else "SINGLE"
             click.echo(
                 click.style(
-                    f"📄 {file_info.file_name}{file_info.file_path.suffix}",
+                    f"📄 {file_info.file_name}{file_info.file_path.suffix}"
+                    f"   ({type_label})",
                     fg="cyan",
                     bold=True,
                 )
@@ -622,17 +653,32 @@ class QuickstartWizard:
 
             # Show schemas
             for schema_name, columns in file_info.inferred_schemas.items():
-                if file_info.is_multi_sheet:
-                    click.echo(f"  Sheet: {schema_name}")
+                if file_info.is_multi_table:
+                    self._echo_group_header(file_info, schema_name)
 
-                # Show first few columns
+                pk_cols = set(file_info.primary_key_columns.get(schema_name, []))
+                fk_map = file_info.nested_foreign_keys.get(schema_name, {})
+
                 col_items = list(columns.items())
                 show_count = min(10, len(col_items))
 
-                for col_name, data_type in col_items[:show_count]:
+                # Right-pad column names within the shown window so the type
+                # column lines up vertically — easier to scan than ragged.
+                shown = col_items[:show_count]
+                width = max((len(name) for name, _ in shown), default=0)
+
+                for col_name, data_type in shown:
                     type_color = self._get_type_color(data_type)
+                    annotations: list[str] = []
+                    if col_name in pk_cols:
+                        annotations.append("primary key")
+                    fk = fk_map.get(col_name)
+                    if fk:
+                        annotations.append(f"foreign key → {fk[0]}.{fk[1]}")
+                    suffix = f"  ({', '.join(annotations)})" if annotations else ""
                     click.echo(
-                        f"    • {col_name}: {click.style(data_type.value, fg=type_color)}"
+                        f"    • {col_name.ljust(width)}  "
+                        f"{click.style(data_type.value, fg=type_color)}{suffix}"
                     )
 
                 if len(col_items) > show_count:
@@ -641,6 +687,22 @@ class QuickstartWizard:
                     )
 
             click.echo()
+
+    @staticmethod
+    def _echo_group_header(file_info, group_name: str) -> None:
+        """Print the ``Group: <name>   (source_path: ...)`` header for a MULTI group.
+
+        XLSX-multi files have no ``source_path`` — they're inherently
+        per-sheet — so the header collapses to the group name alone. Nested
+        JSON renders ``root`` for the parent and the dotted key path for
+        children.
+        """
+        if file_info.is_nested_json:
+            path = file_info.nested_source_paths.get(group_name, ())
+            source_label = ".".join(path) if path else "root"
+            click.echo(f"  Group: {group_name}   (source_path: {source_label})")
+        else:
+            click.echo(f"  Sheet: {group_name}")
 
     def _get_type_color(self, data_type) -> str:
         """Get color for a data type."""

--- a/packages/algomancy-quickstart/src/algomancy_quickstart/quickstart.py
+++ b/packages/algomancy-quickstart/src/algomancy_quickstart/quickstart.py
@@ -35,6 +35,13 @@ class QuickstartWizard:
         self.has_custom_implementations = False
         self.has_generated_etl = False
         self.has_styling = False
+        # When the user declines step 1's "overwrite existing main.py?"
+        # prompt, ``_render_main_py`` becomes a no-op for the rest of the
+        # run — otherwise steps 2/3/5 would silently clobber the file the
+        # user just asked us to leave alone. Only meaningful for re-runs
+        # against an existing project; on a fresh run the file doesn't
+        # exist yet and this stays False.
+        self._preserve_main_py = False
         # Interfaces baked into the generated main.py. GUI is the historical
         # default; the wizard's step_1 prompt may narrow / widen this.
         self.interfaces: list[str] = ["gui"]
@@ -78,15 +85,17 @@ class QuickstartWizard:
         click.echo()
 
         # Step 3: Scan data folder and generate ETL pipeline (optional).
-        # Same pre-set-the-flag pattern as step 2: render with the right
-        # ``has_generated_etl`` value the first time around.
+        # ``has_generated_etl`` is set inside step 3 itself, right before the
+        # main.py re-render, and only when the schemas/etl_factory files
+        # were actually written. Setting it here instead would leave the
+        # flag out of sync with disk (step 3's first main.py render would
+        # see ``has_generated_etl=False``) and would also wrongly mark the
+        # ETL as generated when the user declined the final confirm prompt.
         if click.confirm(
             "Do you want to scan your data folder and generate an ETL pipeline?",
             default=True,
         ):
             self.step_3_generate_etl_from_data()
-            if self.detected_files:  # Only set if files were actually processed
-                self.has_generated_etl = True
 
         click.echo()
 
@@ -232,6 +241,8 @@ class QuickstartWizard:
             if not self.skip_confirmation:
                 if not click.confirm("Do you want to overwrite it?"):
                     click.echo("Skipping main.py generation.")
+                    # Lock subsequent steps out of re-rendering main.py too.
+                    self._preserve_main_py = True
                     return
 
         # Generate main.py from template
@@ -438,6 +449,11 @@ class QuickstartWizard:
         self._generate_etl_factory_file()
         click.echo("  ✓ src/data_handling/etl_factory.py")
 
+        # Flip the flag BEFORE re-rendering main.py — otherwise the template
+        # would emit imports pointing at ``schemas.py`` (the step-2 stub)
+        # rather than ``generated_schemas.py`` that we just wrote.
+        self.has_generated_etl = True
+
         # Update main.py to use generated schemas
         click.echo()
         click.echo("Updating main.py to use generated schemas...")
@@ -596,7 +612,12 @@ class QuickstartWizard:
         target_path.write_text(content, encoding="utf-8")
 
     def _generate_styling_config(self, config: dict):
-        """Generate styling_config.py file."""
+        """Generate styling_config.py file.
+
+        Guarded by the same overwrite-confirm pattern as the schemas / ETL
+        factory writes so a wizard re-run can't silently clobber a
+        user-edited ``styling_config.py``.
+        """
         template = self.jinja_env.get_template("styling_config.py.jinja")
 
         content = template.render(
@@ -614,6 +635,11 @@ class QuickstartWizard:
         )
 
         config_path = self.current_dir / "src" / "styling_config.py"
+
+        if config_path.exists() and not self.skip_confirmation:
+            if not click.confirm(f"File {config_path.name} exists. Overwrite?"):
+                return
+
         config_path.write_text(content, encoding="utf-8")
 
     def _update_main_py_with_styling(self):
@@ -718,7 +744,12 @@ class QuickstartWizard:
         return color_map.get(data_type, "white")
 
     def _generate_schemas_file(self):
-        """Generate the schemas file from detected data."""
+        """Generate the schemas file from detected data.
+
+        Honors the same ``skip_confirmation`` / existing-file dance as
+        :meth:`_generate_etl_factory_file` so a wizard re-run can't silently
+        clobber a user-edited ``generated_schemas.py``.
+        """
         template = self.jinja_env.get_template("generated_schemas.py.jinja")
 
         content = template.render(
@@ -729,6 +760,11 @@ class QuickstartWizard:
         schemas_path = (
             self.current_dir / "src" / "data_handling" / "generated_schemas.py"
         )
+
+        if schemas_path.exists() and not self.skip_confirmation:
+            if not click.confirm(f"File {schemas_path.name} exists. Overwrite?"):
+                return
+
         schemas_path.write_text(content, encoding="utf-8")
 
     def _generate_etl_factory_file(self):
@@ -805,7 +841,13 @@ class QuickstartWizard:
         this, and the template's flags (``interfaces``, ``has_styling``,
         ``has_custom_implementations``, ``has_generated_etl``) take care of
         emitting the right launchers and imports.
+
+        No-op when ``_preserve_main_py`` is set — the user already declined
+        step 1's overwrite prompt, and a later step's re-render would
+        contradict that decision.
         """
+        if self._preserve_main_py:
+            return
         template = self.jinja_env.get_template("main.py.jinja")
         content = template.render(
             title=self.title,

--- a/packages/algomancy-quickstart/tests/test_interface_gating.py
+++ b/packages/algomancy-quickstart/tests/test_interface_gating.py
@@ -1,0 +1,212 @@
+"""Verify the quickstart wizard only emits files relevant to the selected
+interface(s) — issue #170.
+
+These tests drive the wizard end-to-end against the full prompt sequence
+(with click prompts mocked) and assert that GUI-only artifacts (``assets/``,
+``src/pages/``, ``src/styling_config.py``) are present for GUI projects and
+absent for API-only projects.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from algomancy_gui.configuration.colorconfig import ButtonColorMode, CardHighlightMode
+
+from algomancy_quickstart.quickstart import QuickstartWizard
+
+
+_STYLING_CONFIG_STUB = {
+    "background": "#FFFFFF",
+    "primary": "#000000",
+    "secondary": "#666666",
+    "text": "#222222",
+    "text_highlight": "#000000",
+    "text_selected": "#FFFFFF",
+    "button_mode": ButtonColorMode.UNIFIED,
+    "card_mode": CardHighlightMode.LIGHT,
+    "logo_path": None,
+    "button_path": None,
+}
+
+
+def _run_wizard(
+    tmp_path: Path,
+    *,
+    interfaces: str,
+    backend: str = "none",
+    do_custom: bool = True,
+    do_etl: bool = False,
+    do_assets: bool = True,
+    do_styling: bool = True,
+    do_tests: bool = True,
+) -> QuickstartWizard:
+    """Drive the full wizard with mocked click prompts.
+
+    Returns the populated wizard for the caller to make assertions on.
+    """
+    wizard = QuickstartWizard(skip_confirmation=True, title="Gate Test App")
+    wizard.current_dir = tmp_path
+
+    # ``click.prompt`` is consumed in order across steps:
+    #   step 1: host, port, interfaces, backend, (database_url if backend=db)
+    #   step 2: project name
+    #   step 3: (only if scanning succeeds — skipped here)
+    prompts: list = [
+        "127.0.0.1",  # host
+        8050,  # port
+        interfaces,  # interfaces
+        backend,  # backend
+    ]
+    if backend == "database":
+        prompts.append("sqlite:///./gate_test.db")
+    prompts.append("Gate")  # step 2 project name
+
+    # ``click.confirm`` order matches the wizard's ``run()`` body:
+    #   step 2 (custom impls), step 3 (etl), step 4 (assets - GUI only),
+    #   step 5 (styling - GUI only), step 6 (tests).
+    confirms: list[bool] = [do_custom, do_etl]
+    if "gui" in interfaces:
+        confirms.extend([do_assets, do_styling])
+    confirms.append(do_tests)
+
+    with (
+        patch("click.prompt", side_effect=prompts),
+        patch("click.confirm", side_effect=confirms),
+        patch("click.echo"),
+        # Step 4 reaches out to GitHub for default assets — short-circuit it
+        # so the test stays offline. We only care that the prompt was made.
+        patch.object(wizard.asset_manager, "install_assets", return_value=True),
+        # Step 5's interactive styling wizard has its own click prompt
+        # ladder; stub it out and return a canned config so the wizard
+        # treats the step as successful and renders ``main.py`` with the
+        # ``has_styling=True`` branch.
+        patch.object(
+            wizard.styling_wizard, "run", return_value=dict(_STYLING_CONFIG_STUB)
+        ),
+    ):
+        wizard.run()
+
+    return wizard
+
+
+class TestApiOnlyNoGuiArtifacts:
+    """API-only projects must not produce GUI-only files or folders."""
+
+    def test_no_assets_folder(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="api")
+        assert not (tmp_path / "assets").exists()
+
+    def test_no_pages_folder(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="api")
+        assert not (tmp_path / "src" / "pages").exists()
+
+    def test_no_styling_config(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="api")
+        assert not (tmp_path / "src" / "styling_config.py").exists()
+
+    def test_non_gui_artifacts_still_present(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="api")
+        # main.py, src/, data/setup/, custom impl files all stay.
+        assert (tmp_path / "main.py").exists()
+        assert (tmp_path / "data" / "setup").exists()
+        assert (tmp_path / "src" / "data_handling" / "schemas.py").exists()
+        assert (tmp_path / "src" / "data_handling" / "etl_factory.py").exists()
+        assert (tmp_path / "src" / "templates" / "algorithm").exists()
+        assert (tmp_path / "src" / "templates" / "kpi").exists()
+
+
+class TestGuiProjectStillHasGuiArtifacts:
+    """Regression guard — GUI projects keep emitting all GUI artifacts."""
+
+    def test_assets_folder_created(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="gui")
+        assert (tmp_path / "assets").exists()
+
+    def test_pages_folder_and_files_created(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="gui")
+        pages = tmp_path / "src" / "pages"
+        assert pages.exists()
+        for name in (
+            "home_page.py",
+            "data_page.py",
+            "scenario_page.py",
+            "compare_page.py",
+            "overview_page.py",
+        ):
+            assert (pages / name).exists(), f"missing {name}"
+
+    def test_styling_config_created(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="gui")
+        assert (tmp_path / "src" / "styling_config.py").exists()
+
+
+class TestMultiInterfaceGetsEverything:
+    """``gui,api`` is the union — every GUI artifact should still appear."""
+
+    def test_multi_interface_emits_gui_artifacts(self, tmp_path):
+        _run_wizard(tmp_path, interfaces="gui,api")
+        assert (tmp_path / "assets").exists()
+        assert (tmp_path / "src" / "pages" / "home_page.py").exists()
+        assert (tmp_path / "src" / "styling_config.py").exists()
+
+
+class TestNoUnreferencedFiles:
+    """Every emitted ``src/`` Python file must be reachable from ``main.py``.
+
+    We approximate "reachable" by parsing ``main.py`` for ``from src...
+    import`` statements and confirming the corresponding modules exist —
+    which is the inverse of the audit complaint in #170, where ``main.py``
+    didn't import the GUI pages but they were emitted anyway.
+    """
+
+    @pytest.mark.parametrize("interfaces", ["gui", "api", "gui,api"])
+    def test_no_orphan_src_modules(self, tmp_path, interfaces):
+        _run_wizard(tmp_path, interfaces=interfaces)
+
+        # Collect ``.py`` files under src/ (excluding __init__.py).
+        src_files: set[Path] = set()
+        src_root = tmp_path / "src"
+        for path in src_root.rglob("*.py"):
+            if path.name == "__init__.py":
+                continue
+            src_files.add(path.relative_to(tmp_path))
+
+        # Approximate reachability: read main.py and walk imports recursively.
+        main_py = (tmp_path / "main.py").read_text(encoding="utf-8")
+        reachable: set[Path] = set()
+        frontier = [main_py]
+        while frontier:
+            source = frontier.pop()
+            for line in source.splitlines():
+                line = line.strip()
+                if not line.startswith("from src."):
+                    continue
+                # e.g. "from src.pages.home_page import X"
+                module = line.split()[1]
+                rel = Path(*module.split(".")).with_suffix(".py")
+                if rel in reachable:
+                    continue
+                target = tmp_path / rel
+                if target.exists():
+                    reachable.add(rel)
+                    frontier.append(target.read_text(encoding="utf-8"))
+
+        # For an API-only project, no ``src/pages/`` files should exist at
+        # all — the strongest form of "no orphans". The reachability check
+        # below subsumes this but the explicit message is more useful.
+        if "gui" not in interfaces:
+            orphan_pages = {p for p in src_files if p.parts[:2] == ("src", "pages")}
+            assert not orphan_pages, f"API-only project shipped pages: {orphan_pages}"
+
+        # Any src file that exists but is not reachable from main.py is an
+        # orphan. Files under ``src/data_handling/`` are always reachable
+        # because main.py imports them directly; ``src/templates/...`` are
+        # imported when ``has_custom_implementations``.
+        orphans = src_files - reachable
+        assert not orphans, (
+            f"Unreferenced src files for interfaces={interfaces}: {sorted(orphans)}"
+        )

--- a/packages/algomancy-quickstart/tests/test_nested_json_inference.py
+++ b/packages/algomancy-quickstart/tests/test_nested_json_inference.py
@@ -26,6 +26,7 @@ from algomancy_data import (
     JSONFile,
     JSONMultiExtractor,
     Schema,
+    SimpleETLFactory,
 )
 from algomancy_data.schema import SchemaType
 from algomancy_quickstart.data_inference import DataFileInfo, SchemaInferenceEngine
@@ -187,6 +188,39 @@ class TestTemplate:
         child = out["picks.PickOrderLines"]
         by_id = dict(zip(child["Identity"], child["PickLoadCarriersIdentity"]))
         assert by_id == {"L1": "29036570", "L2": "29036570", "L3": "29036571"}
+
+    def test_rendered_schema_survives_full_etl_pipeline(self, tmp_path, jinja_env):
+        """Regression for issue #172: the rendered MULTI schema must also
+        survive ``SimpleETLFactory.build_pipeline().run()`` end-to-end, not
+        just direct extraction. The previous validator gate at
+        ``etl.py:339`` invoked ``primary_key()`` on the MULTI schema and
+        crashed via the SINGLE-only ``columns()`` path.
+        """
+        engine = SchemaInferenceEngine()
+        info = _write(tmp_path, SAMPLE_NESTED_JSON)
+        with patch("click.confirm", return_value=True):
+            engine._infer_schema_with_config(info)
+        info.total_columns = sum(len(c) for c in info.inferred_schemas.values())
+
+        tmpl = jinja_env.get_template("generated_schemas.py.jinja")
+        rendered = tmpl.render(project_name="Demo", files=[info])
+
+        ns: dict = {}
+        exec(  # noqa: S102 - controlled template output, no user code
+            compile(rendered, "<generated_schemas>", "exec"), ns, ns
+        )
+        SchemaCls = ns["PicksSchema"]
+
+        files = {"picks": JSONFile(name="picks", path=str(info.file_path))}
+        result = (
+            SimpleETLFactory(schemas=[SchemaCls]).build_pipeline("picks", files).run()
+        )
+
+        assert result.is_success, [m.message for m in result.messages]
+        parent = result.datasource.get_table("picks.PickLoadCarriers")
+        child = result.datasource.get_table("picks.PickOrderLines")
+        assert len(parent) == 2
+        assert len(child) == 3
 
 
 # --------------------------------------------------------------------- #

--- a/packages/algomancy-quickstart/tests/test_nested_json_inference.py
+++ b/packages/algomancy-quickstart/tests/test_nested_json_inference.py
@@ -30,6 +30,7 @@ from algomancy_data import (
 )
 from algomancy_data.schema import SchemaType
 from algomancy_quickstart.data_inference import DataFileInfo, SchemaInferenceEngine
+from algomancy_quickstart.quickstart import QuickstartWizard
 
 
 SAMPLE_NESTED_JSON = {
@@ -221,6 +222,69 @@ class TestTemplate:
         child = result.datasource.get_table("picks.PickOrderLines")
         assert len(parent) == 2
         assert len(child) == 3
+
+
+# --------------------------------------------------------------------- #
+# Summary rendering (issue #171)
+# --------------------------------------------------------------------- #
+
+
+class TestSummaryDisplay:
+    def _build_wizard_with_nested(self, tmp_path: Path) -> QuickstartWizard:
+        engine = SchemaInferenceEngine()
+        info = _write(tmp_path, SAMPLE_NESTED_JSON)
+        with patch("click.confirm", return_value=True):
+            engine._infer_schema_with_config(info)
+        info.total_columns = sum(len(c) for c in info.inferred_schemas.values())
+
+        wizard = QuickstartWizard(skip_confirmation=True)
+        wizard.current_dir = tmp_path
+        wizard.detected_files = [info]
+        return wizard
+
+    def test_multi_groups_render_with_source_path_and_fk(self, tmp_path):
+        wizard = self._build_wizard_with_nested(tmp_path)
+        captured: list[str] = []
+
+        def _capture(msg="", *a, **kw):  # match click.echo signature
+            captured.append(str(msg))
+
+        with patch("click.echo", side_effect=_capture):
+            wizard._display_inferred_schemas_summary()
+
+        text = "\n".join(captured)
+        assert "(MULTI)" in text
+        assert "Group: PickLoadCarriers" in text
+        assert "source_path: root" in text
+        assert "Group: PickOrderLines" in text
+        assert "source_path: PickOrderLines" in text
+        # Primary keys annotated.
+        assert "primary key" in text
+        # Foreign key annotation references the parent table + col.
+        assert "foreign key → PickLoadCarriers.Identity" in text
+
+    def test_flat_json_renders_as_single(self, tmp_path):
+        engine = SchemaInferenceEngine()
+        info = _write(tmp_path, [{"id": "a", "v": 1}], name="flat")
+        with patch("click.confirm") as confirm:
+            engine._infer_schema_with_config(info)
+            confirm.assert_not_called()
+        info.total_columns = len(info.inferred_schemas["default"])
+
+        wizard = QuickstartWizard(skip_confirmation=True)
+        wizard.current_dir = tmp_path
+        wizard.detected_files = [info]
+
+        captured: list[str] = []
+        with patch(
+            "click.echo", side_effect=lambda msg="", *a, **kw: captured.append(str(msg))
+        ):
+            wizard._display_inferred_schemas_summary()
+
+        text = "\n".join(captured)
+        assert "(SINGLE)" in text
+        assert "Group:" not in text
+        assert "source_path" not in text
 
 
 # --------------------------------------------------------------------- #

--- a/packages/algomancy-quickstart/tests/test_override_safety.py
+++ b/packages/algomancy-quickstart/tests/test_override_safety.py
@@ -1,0 +1,267 @@
+"""Override-safety tests for the wizard.
+
+Covers the three classes of bug surfaced in the file-write audit:
+
+* **B1** — ``has_generated_etl`` ordering. After step 3 runs in an API-only
+  project, ``main.py`` must import ``all_schemas`` from
+  ``generated_schemas.py`` (the file step 3 just wrote), NOT from
+  ``schemas.py`` (the step-2 stub). Previously the flag was set in
+  ``run()`` after step 3 returned, so step 3's own main.py render saw
+  ``has_generated_etl=False`` and emitted the wrong import.
+* **B2** — declining the final "Generate ETL with these configurations?"
+  prompt must leave ``has_generated_etl=False`` (no files were written).
+* **B5** — re-running the wizard against an existing project must NOT
+  silently clobber user-edited ``generated_schemas.py``,
+  ``styling_config.py``, or ``main.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from algomancy_gui.configuration.colorconfig import ButtonColorMode, CardHighlightMode
+
+from algomancy_quickstart.quickstart import QuickstartWizard
+
+
+_STYLING_CONFIG_STUB = {
+    "background": "#FFFFFF",
+    "primary": "#000000",
+    "secondary": "#666666",
+    "text": "#222222",
+    "text_highlight": "#000000",
+    "text_selected": "#FFFFFF",
+    "button_mode": ButtonColorMode.UNIFIED,
+    "card_mode": CardHighlightMode.LIGHT,
+    "logo_path": None,
+    "button_path": None,
+}
+
+
+def _seed_csv(tmp_path: Path) -> None:
+    (tmp_path / "data" / "setup").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "data" / "setup" / "orders.csv").write_text(
+        "id,name\n1,a\n2,b\n", encoding="utf-8"
+    )
+
+
+class TestB1HasGeneratedEtlOrdering:
+    """API-only + step 2 + step 3 must end with the right schema import."""
+
+    def test_api_only_main_py_imports_generated_schemas(self, tmp_path):
+        _seed_csv(tmp_path)
+        wizard = QuickstartWizard(skip_confirmation=True, title="B1 Test")
+        wizard.current_dir = tmp_path
+
+        # step 1: host, port, interfaces=api, backend=none
+        # step 2: project name
+        # step 3 inference: CSV separator (one CSV)
+        prompts = ["127.0.0.1", 8050, "api", "none", "B1", ","]
+        # step 2 yes, step 3 yes, step 3-per-file yes, step 6 yes
+        confirms = [True, True, True, True]
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+        ):
+            wizard.run()
+
+        main = (tmp_path / "main.py").read_text(encoding="utf-8")
+        assert "from src.data_handling.generated_schemas import all_schemas" in main, (
+            f"Expected generated_schemas import.\nGot:\n{main}"
+        )
+        assert "from src.data_handling.schemas import all_schemas" not in main, (
+            "Step-2 stub schemas import leaked through despite step 3 running."
+        )
+        assert wizard.has_generated_etl is True
+
+
+class TestB2DeclinedFinalConfirmDoesNotFlipFlag:
+    """Declining D18 must leave has_generated_etl=False and no ETL files."""
+
+    def test_decline_step3_final_confirm(self, tmp_path):
+        _seed_csv(tmp_path)
+        # ``not skip_confirmation`` is required for D18 to even surface.
+        wizard = QuickstartWizard(skip_confirmation=False, title="B2 Test")
+        wizard.current_dir = tmp_path
+
+        prompts = ["127.0.0.1", 8050, "api", "none", "B2", ","]
+        # confirms in order:
+        #   step 2 yes
+        #   step 3 outer yes
+        #   step 3 per-file include yes
+        #   step 3 final D18 NO       <-- the decline under test
+        #   step 6 yes
+        # (No per-file overwrite confirms triggered: fresh project, files
+        # don't pre-exist. Step 2's main.py write is also fresh.)
+        confirms = [True, True, True, False, True]
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+        ):
+            wizard.run()
+
+        assert wizard.has_generated_etl is False
+        assert not (
+            tmp_path / "src" / "data_handling" / "generated_schemas.py"
+        ).exists()
+        main = (tmp_path / "main.py").read_text(encoding="utf-8")
+        # Step 2 ran (yes to D9), so main.py uses the custom-impl branch
+        # pointing at the step-2 stubs — NOT generated_schemas.
+        assert "from src.data_handling.schemas import all_schemas" in main
+        assert "from src.data_handling.generated_schemas" not in main
+
+
+class TestB5RerunOverwriteGuards:
+    """Files that previously got silently clobbered now ask first."""
+
+    def _seed_full_project(self, tmp_path: Path) -> QuickstartWizard:
+        """First wizard pass — produces a GUI project with all artifacts."""
+        _seed_csv(tmp_path)
+        wizard = QuickstartWizard(skip_confirmation=True, title="Seed")
+        wizard.current_dir = tmp_path
+
+        prompts = ["127.0.0.1", 8050, "gui", "none", "Seed", ","]
+        # step 2, step 3 outer, step 3 per-file, step 4 assets, step 5
+        # styling, step 6 tests
+        confirms = [True, True, True, True, True, True]
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+            patch.object(wizard.asset_manager, "install_assets", return_value=True),
+            patch.object(
+                wizard.styling_wizard, "run", return_value=dict(_STYLING_CONFIG_STUB)
+            ),
+        ):
+            wizard.run()
+        return wizard
+
+    def test_decline_main_py_overwrite_blocks_subsequent_renders(self, tmp_path):
+        """Step 1 D8=no must prevent step 2/3/5 from rewriting main.py."""
+        self._seed_full_project(tmp_path)
+        sentinel = "# HAND EDITED — DO NOT OVERWRITE\n"
+        (tmp_path / "main.py").write_text(sentinel, encoding="utf-8")
+
+        wizard = QuickstartWizard(skip_confirmation=False, title="B5 main.py")
+        wizard.current_dir = tmp_path
+
+        # Re-run prompts: host, port, interfaces, backend, project_name, csv_sep
+        prompts = ["127.0.0.1", 8050, "gui", "none", "B5", ","]
+        # Confirms in order:
+        #   1. step 1 folders-exist confirm (yes, continue)
+        #   2. step 1 main.py overwrite (NO — the decline under test)
+        #   3. step 2 outer yes
+        #   4-9. per-file overwrite confirms in step 2 — say NO to keep
+        #        the existing files in place (we only care about main.py
+        #        here, but declining keeps the test deterministic)
+        #   10. step 3 outer yes
+        #   11. step 3 per-file include yes
+        #   12. step 3 D18 final yes
+        #   13. step 3 etl_factory overwrite — NO (keep stub)
+        #   14. step 3 generated_schemas overwrite — NO (keep stub)
+        #   15. step 4 assets yes
+        #   16. step 5 styling yes
+        #   17. step 5 styling_config overwrite — NO
+        #   18. step 6 tests yes
+        #   19-22. test file overwrite confirms — NO
+        confirms = [True, False] + [False] * 20
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+            patch.object(wizard.asset_manager, "install_assets", return_value=True),
+            patch.object(
+                wizard.styling_wizard, "run", return_value=dict(_STYLING_CONFIG_STUB)
+            ),
+        ):
+            wizard.run()
+
+        # The sentinel survives — no step rewrote main.py.
+        assert (tmp_path / "main.py").read_text(encoding="utf-8") == sentinel
+
+    def test_decline_generated_schemas_overwrite(self, tmp_path):
+        """B5: declining the new generated_schemas.py overwrite confirm
+        must preserve the user-edited file."""
+        self._seed_full_project(tmp_path)
+        sentinel = "# user edits go here\nall_schemas = []\n"
+        schemas_path = tmp_path / "src" / "data_handling" / "generated_schemas.py"
+        schemas_path.write_text(sentinel, encoding="utf-8")
+
+        wizard = QuickstartWizard(skip_confirmation=False, title="B5 schemas")
+        wizard.current_dir = tmp_path
+
+        prompts = ["127.0.0.1", 8050, "gui", "none", "B5", ","]
+        # 1. folders-exist yes
+        # 2. main.py overwrite YES
+        # 3. step 2 yes
+        # 4-9. step 2 per-file overwrite YES
+        # 10. step 3 outer yes
+        # 11. step 3 per-file include yes
+        # 12. step 3 D18 final yes
+        # 13. step 3 etl_factory overwrite YES
+        # 14. step 3 generated_schemas overwrite NO  <-- decline under test
+        # 15. step 4 assets yes
+        # 16. step 5 styling yes
+        # 17. step 5 styling_config overwrite YES
+        # 18. step 6 tests yes
+        # 19-22. test file overwrite YES
+        confirms = (
+            [True, True, True]
+            + [True] * 6
+            + [True, True, True, True, False, True, True, True, True]
+            + [True] * 4
+        )
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+            patch.object(wizard.asset_manager, "install_assets", return_value=True),
+            patch.object(
+                wizard.styling_wizard, "run", return_value=dict(_STYLING_CONFIG_STUB)
+            ),
+        ):
+            wizard.run()
+
+        assert schemas_path.read_text(encoding="utf-8") == sentinel
+
+    def test_decline_styling_config_overwrite(self, tmp_path):
+        """B5: declining the new styling_config.py overwrite confirm
+        must preserve the user-edited file."""
+        self._seed_full_project(tmp_path)
+        sentinel = "# user styling\napp_styling = None\n"
+        styling_path = tmp_path / "src" / "styling_config.py"
+        styling_path.write_text(sentinel, encoding="utf-8")
+
+        wizard = QuickstartWizard(skip_confirmation=False, title="B5 styling")
+        wizard.current_dir = tmp_path
+
+        prompts = ["127.0.0.1", 8050, "gui", "none", "B5", ","]
+        # Same flow as above; only difference is the styling_config
+        # overwrite is declined and earlier ones are accepted.
+        confirms = (
+            [True, True, True]
+            + [True] * 6
+            + [True, True, True, True, True, True, True, False, True]
+            + [True] * 4
+        )
+
+        with (
+            patch("click.prompt", side_effect=prompts),
+            patch("click.confirm", side_effect=confirms),
+            patch("click.echo"),
+            patch.object(wizard.asset_manager, "install_assets", return_value=True),
+            patch.object(
+                wizard.styling_wizard, "run", return_value=dict(_STYLING_CONFIG_STUB)
+            ),
+        ):
+            wizard.run()
+
+        assert styling_path.read_text(encoding="utf-8") == sentinel


### PR DESCRIPTION
Wraps up the JSON-multi quickstart work by closing #170, #171, and #173, plus a follow-on audit of the wizard's file-write ordering that surfaced three real bugs (one of which causes API-only projects to import the wrong schemas file).

## Summary

- **#171 — MULTI schema groups in the inferred-schemas summary.** `_display_inferred_schemas_summary` now renders a typed header (`(MULTI)` / `(SINGLE)`), per-group sections with `source_path`, and primary-key / foreign-key annotations on each column. Nested-JSON parent/child structure is finally visible to the user before they confirm generation.
- **#170 — Prune wizard branching by interface.** GUI-only artifacts are no longer emitted for API-only projects:
  - step 1 skips creating `assets/` and `src/pages/`
  - step 2 skips the five page-template files
  - steps 4 (assets) and 5 (styling) are not prompted when `gui` is not in `interfaces`
- **#173 — HTTP API reference for non-trivial endpoints.** `docs/source/reference/api.md` gained per-endpoint sections for `POST /etl` (full multipart shape + curl/httpx examples + error matrix), `POST /scenarios` (body table with discovery hints), `POST /scenarios/{id}/run` (state machine + fire-and-forget semantics), `POST /data/from-json` (raw-body forwarding), and a dedicated "Scenario response shape" subsection covering `Scenario.to_dict()`. Notes that there is no separate `/kpi-measurements` endpoint — KPI values are part of the scenario payload.
- **Audit follow-up.** A full inventory of file-write sites + decision points caught three override / ordering bugs:
  - **B1** — `has_generated_etl` was set in `run()` *after* step 3 returned, so step 3's own `main.py` render saw the flag still `False`. API-only projects ended up with `from src.data_handling.schemas import all_schemas` (the step-2 stub) instead of `from src.data_handling.generated_schemas import all_schemas`. The flag is now flipped inside step 3 immediately before the re-render.
  - **B2** — declining the final "Generate ETL with these configurations?" prompt used to leave `has_generated_etl=True` despite no files being written. Fixed by B1's move.
  - **B5** — re-running the wizard in an existing project silently clobbered `generated_schemas.py`, `styling_config.py`, and any user-edited `main.py` (because steps 2/3/5 re-render `main.py` unconditionally). Added the standard `exists and not skip_confirmation` confirm to the two file writers, plus a `_preserve_main_py` flag that propagates step 1's D8 "no, don't overwrite" decision through every later step's re-render.
- Pre-existing ordering bug for `has_custom_implementations` (same shape as B1, masked in GUI flows by step 5's re-render) fixed in the same pass.

## Test plan

- [x] `uv run pytest packages/algomancy-quickstart/tests tests` — 111 passed, 1 skipped
- [x] New `test_interface_gating.py` — 11 tests covering folder/file presence/absence for `gui` / `api` / `gui,api` plus an orphan-reachability check that walks `main.py` imports
- [x] New `test_override_safety.py` — 5 tests covering B1 (API-only ends up with `generated_schemas` import), B2 (D18 decline leaves flag False and no schema file), B5 (declined overwrite of `main.py` / `generated_schemas.py` / `styling_config.py` preserves user edits)
- [x] New summary-display tests in `test_nested_json_inference.py`
- [x] Existing smoke + template-modernization tests still green across all interface/backend combinations
- [x] `uv run sphinx-build` produces no new warnings on `reference/api.md`
- [x] `ruff check` and `ruff format --check` clean on touched files

## Docs

- `docs/source/getting_started/quickstart.md` updated to call out interface-conditional artifacts in the directory trees and to describe the interface / persistence-backend prompts in step 1.
- `docs/source/reference/api.md` expanded with the new per-endpoint sections described above.