### PR TITLE
Add allow_session_create flag to ApiConfiguration (#211)

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,6 +3,9 @@
 > Migrating from v0.5 or earlier? See the [migration guide](migration-ref)
 > for before/after snippets covering every breaking change in v0.6–v0.7.
 ## v0.8.4
+### Added
+- **`ApiConfiguration.allow_session_create`** — when `False`, the HTTP API rejects `POST /sessions` and `POST /sessions/{id}/copy` with `403 Forbidden`. Mirrors the GUI's `FeatureConfig.show_session_picker=False` for single-tenant deployments where the operator has provisioned the session(s) up front. List / rename / delete on existing sessions, and all per-session routes, are unaffected.
+
 ### Fixed
 - **GUI landing smoke test** — wait for `document.title` to settle on the configured app title before asserting on `page.content()`; previously a `domcontentloaded` race could capture HTML while Dash had swapped the title to `update_title` ("Updating…").
 - **Persistence smoke `_create_and_run_scenario` helper** — only issue an explicit `POST …/run` when the scenario is still in `CREATED` status after create; under `autorun=True` the scenario may already be queued/complete, which previously caused a spurious `409` against the new strict `/run` contract.

--- a/docs/source/fundamentals/sessions.md
+++ b/docs/source/fundamentals/sessions.md
@@ -167,6 +167,15 @@ useful for single-tenant deployments where the user shouldn't be
 switching contexts. Sessions still exist underneath, the UI just doesn't
 expose the controls.
 
+The HTTP API has an equivalent switch:
+`ApiConfiguration(allow_session_create=False)`. When set, the
+`POST /sessions` and `POST /sessions/{id}/copy` routes return `403
+Forbidden`; listing, renaming, and deleting existing sessions still
+work, and per-session routes (scenarios, data, algorithms, KPIs) are
+unaffected. Use this in single-tenant deployments where the operator
+has provisioned the session(s) up front and clients should not be able
+to add new ones.
+
 See also: {ref}`Frontends <fundamentals-frontends-ref>` for how the
 GUI and API consume the SessionManager, and {ref}`HTTP API
 reference <api-ref>` for the full session route shape.

--- a/packages/algomancy-api/src/algomancy_api/api_configuration.py
+++ b/packages/algomancy-api/src/algomancy_api/api_configuration.py
@@ -9,7 +9,7 @@ class ApiConfiguration(CoreConfig):
     """Configuration for the HTTP API server.
 
     Extends :class:`CoreConfig` with HTTP-specific options: bind host/port,
-    URL prefix, and CORS origins.
+    URL prefix, CORS origins, and session-creation policy.
     """
 
     def __init__(
@@ -33,6 +33,7 @@ class ApiConfiguration(CoreConfig):
         port: int = 8051,
         prefix: str = "/api/v1",
         cors_origins: List[str] | None = None,
+        allow_session_create: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(
@@ -55,6 +56,7 @@ class ApiConfiguration(CoreConfig):
         self.port = port
         self.prefix = prefix
         self.cors_origins = list(cors_origins) if cors_origins else []
+        self.allow_session_create = allow_session_create
         self._validate_api()
 
     def as_dict(self) -> Dict[str, Any]:
@@ -65,6 +67,7 @@ class ApiConfiguration(CoreConfig):
                 "port": self.port,
                 "prefix": self.prefix,
                 "cors_origins": list(self.cors_origins),
+                "allow_session_create": self.allow_session_create,
             }
         )
         return base
@@ -78,3 +81,5 @@ class ApiConfiguration(CoreConfig):
             raise ValueError("prefix must be a string starting with '/'")
         if any(not isinstance(o, str) or not o for o in self.cors_origins):
             raise ValueError("cors_origins entries must be non-empty strings")
+        if not isinstance(self.allow_session_create, bool):
+            raise ValueError("allow_session_create must be a bool")

--- a/packages/algomancy-api/src/algomancy_api/dependencies.py
+++ b/packages/algomancy-api/src/algomancy_api/dependencies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import HTTPException, Path, Request
+from fastapi import HTTPException, Path, Request, status
 
 from algomancy_scenario import ScenarioManager, SessionManager
 
@@ -12,6 +12,22 @@ def get_session_manager(request: Request) -> SessionManager:
         # Shouldn't happen unless the app was constructed outside ApiLauncher.build.
         raise HTTPException(status_code=500, detail="SessionManager not configured")
     return sm
+
+
+def require_session_create_allowed(request: Request) -> None:
+    """403 when the server is configured to disallow new-session creation.
+
+    Mirrors the GUI's ``FeatureConfig.show_session_picker=False`` flag: useful
+    for single-tenant deployments where the operator has provisioned the
+    session(s) up front and wants the HTTP surface to reject create / copy
+    attempts rather than letting clients quietly add new sessions.
+    """
+    cfg = getattr(request.app.state, "config", None)
+    if cfg is not None and not getattr(cfg, "allow_session_create", True):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session creation is disabled on this server",
+        )
 
 
 def resolve_session_id(sm: SessionManager, session_id_or_name: str) -> str | None:

--- a/packages/algomancy-api/src/algomancy_api/routers/sessions.py
+++ b/packages/algomancy-api/src/algomancy_api/routers/sessions.py
@@ -15,7 +15,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from algomancy_scenario import SessionManager
 
-from ..dependencies import get_session_manager, resolve_session_id
+from ..dependencies import (
+    get_session_manager,
+    require_session_create_allowed,
+    resolve_session_id,
+)
 from ..schemas import (
     CopySessionRequest,
     CreateSessionRequest,
@@ -51,6 +55,7 @@ def list_sessions(
     status_code=status.HTTP_201_CREATED,
     response_model=SessionsListResponse,
     summary="Create a new empty session",
+    dependencies=[Depends(require_session_create_allowed)],
 )
 def create_session(
     body: CreateSessionRequest,
@@ -68,6 +73,7 @@ def create_session(
     status_code=status.HTTP_201_CREATED,
     response_model=SessionsListResponse,
     summary="Copy an existing session under a new display name",
+    dependencies=[Depends(require_session_create_allowed)],
 )
 def copy_session(
     session_id: str,

--- a/packages/algomancy-api/tests/test_api_configuration.py
+++ b/packages/algomancy-api/tests/test_api_configuration.py
@@ -11,6 +11,7 @@ def test_defaults(api_core_kwargs):
     assert cfg.port == 8051
     assert cfg.prefix == "/api/v1"
     assert cfg.cors_origins == []
+    assert cfg.allow_session_create is True
 
 
 def test_overrides(api_core_kwargs):
@@ -37,6 +38,13 @@ def test_as_dict_includes_api_fields(api_core_kwargs):
     assert d["port"] == 8052
     assert d["prefix"] == "/api/v1"
     assert d["cors_origins"] == []
+    assert d["allow_session_create"] is True
+
+
+def test_allow_session_create_can_be_disabled(api_core_kwargs):
+    cfg = ApiConfiguration(allow_session_create=False, **api_core_kwargs)
+    assert cfg.allow_session_create is False
+    assert cfg.as_dict()["allow_session_create"] is False
 
 
 @pytest.mark.parametrize(
@@ -51,6 +59,8 @@ def test_as_dict_includes_api_fields(api_core_kwargs):
         {"prefix": 123},
         {"cors_origins": [""]},
         {"cors_origins": [42]},
+        {"allow_session_create": "yes"},
+        {"allow_session_create": None},
     ],
 )
 def test_invalid_api_fields_rejected(api_core_kwargs, kwarg):

--- a/packages/algomancy-api/tests/test_sessions_router.py
+++ b/packages/algomancy-api/tests/test_sessions_router.py
@@ -30,6 +30,17 @@ def app_sessions(api_core_kwargs, tmp_path) -> FastAPI:
     return ApiLauncher.build(cfg)
 
 
+@pytest.fixture
+def app_sessions_create_disabled(api_core_kwargs, tmp_path) -> FastAPI:
+    """Same setup as ``app_sessions`` but with ``allow_session_create=False``."""
+    (tmp_path / "alpha").mkdir(exist_ok=True)
+    (tmp_path / "beta").mkdir(exist_ok=True)
+    kwargs = dict(api_core_kwargs)
+    kwargs["data_path"] = str(tmp_path)
+    cfg = ApiConfiguration(allow_session_create=False, **kwargs)
+    return ApiLauncher.build(cfg)
+
+
 def _ids_by_display_name(client: TestClient) -> dict[str, str]:
     body = client.get("/api/v1/sessions").json()
     return {s["display_name"]: s["id"] for s in body["sessions"]}
@@ -195,6 +206,48 @@ def test_delete_last_session_creates_default_replacement(app_empty_sessions):
     assert refreshed["sessions"][0]["display_name"] == "main"
     # The replacement session has a fresh UUID — id is not reused.
     assert refreshed["sessions"][0]["id"] != only_id
+
+
+def test_create_session_forbidden_when_disabled(app_sessions_create_disabled):
+    client = TestClient(app_sessions_create_disabled)
+    r = client.post("/api/v1/sessions", json={"display_name": "gamma"})
+    assert r.status_code == 403
+    assert "disabled" in r.json()["detail"].lower()
+
+    # List still works; nothing was added.
+    names = {
+        s["display_name"] for s in client.get("/api/v1/sessions").json()["sessions"]
+    }
+    assert "gamma" not in names
+
+
+def test_copy_session_forbidden_when_disabled(app_sessions_create_disabled):
+    client = TestClient(app_sessions_create_disabled)
+    ids = _ids_by_display_name(client)
+    r = client.post(
+        f"/api/v1/sessions/{ids['alpha']}/copy",
+        json={"new_display_name": "alpha-copy"},
+    )
+    assert r.status_code == 403
+
+
+def test_rename_and_delete_still_work_when_create_disabled(
+    app_sessions_create_disabled,
+):
+    """Disabling create only blocks new-session ingress — existing sessions
+    remain fully manageable (rename, delete)."""
+    client = TestClient(app_sessions_create_disabled)
+    ids = _ids_by_display_name(client)
+    alpha_id = ids["alpha"]
+
+    r = client.patch(
+        f"/api/v1/sessions/{alpha_id}",
+        json={"display_name": "alpha-renamed"},
+    )
+    assert r.status_code == 200
+
+    r = client.delete(f"/api/v1/sessions/{ids['beta']}")
+    assert r.status_code == 200
 
 
 def test_openapi_lists_session_routes(app_sessions):


### PR DESCRIPTION
## Summary

Closes #211.

- Adds `ApiConfiguration.allow_session_create: bool = True`. When `False`, the API rejects `POST /sessions` and `POST /sessions/{id}/copy` with `403 Forbidden`. Mirrors the GUI's `FeatureConfig.show_session_picker=False`.
- `list_sessions`, `rename_session`, `delete_session`, and every per-session route (scenarios, data, algorithms, KPIs) remain unaffected — the flag only blocks new-session ingress.
- Implemented as a `require_session_create_allowed` FastAPI dependency on the two relevant routes, so the 403 surfaces in the OpenAPI schema and route logic stays untouched.

## Test plan

- [x] `uv run pytest packages/algomancy-api/tests/test_api_configuration.py packages/algomancy-api/tests/test_sessions_router.py -v` — 35 passed, including:
  - `test_allow_session_create_can_be_disabled`
  - `test_invalid_api_fields_rejected[allow_session_create=...]`
  - `test_create_session_forbidden_when_disabled`
  - `test_copy_session_forbidden_when_disabled`
  - `test_rename_and_delete_still_work_when_create_disabled`
- [x] Pre-commit (ruff format + check) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)