### PR TITLE
Fix DatabaseDataManager dtype coercion on SQL round-trip (#221)

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -9,6 +9,7 @@
 ### Fixed
 - **GUI landing smoke test** — wait for `document.title` to settle on the configured app title before asserting on `page.content()`; previously a `domcontentloaded` race could capture HTML while Dash had swapped the title to `update_title` ("Updating…").
 - **Persistence smoke `_create_and_run_scenario` helper** — only issue an explicit `POST …/run` when the scenario is still in `CREATED` status after create; under `autorun=True` the scenario may already be queued/complete, which previously caused a spurious `409` against the new strict `/run` contract.
+- **`DatabaseDataManager` dtype round-trip** — DataFrames returned from `get_data` now match the dtypes declared by the registered `Schema` for that sub-table. Previously, SQLite-backed `BOOLEAN` columns came back as `int64`, `INTEGER` columns with nulls as `float64`, and `DATETIME` columns as `object` — downstream code that relied on the declared dtype (e.g. constructing dataclasses with `bool` fields) silently received the wrong type. Coercion is keyed on `Schema.file_name()` (with `<file>.<sub>` for MULTI schemas); sub-tables without a matching schema are unaffected.
 
 ## v0.8.3
 ### Added

--- a/packages/algomancy-data/src/algomancy_data/database/database_manager.py
+++ b/packages/algomancy-data/src/algomancy_data/database/database_manager.py
@@ -30,6 +30,7 @@ from ..datamanager import DataManager
 from ..datasource import DataClassification, BASEDATASOURCE
 from ..etl import ETLResult
 from ..schema import Schema
+from ..validator import schema_table_map
 from .models import (
     DATA_TABLE_PREFIX,
     DATASET_COL,
@@ -38,6 +39,7 @@ from .models import (
     metadata as _catalogue_metadata,
 )
 from .protocols import SqlTableLayout
+from .schema_translator import coerce_dataframe_to_schema
 
 if TYPE_CHECKING:
     pass
@@ -234,6 +236,17 @@ class DatabaseDataManager(DataManager):
                 {"sid": self._session_id, "name": dataset_name},
             )
 
+    def _schema_for_subtable(self, sub_table: str) -> Optional[Schema]:
+        """Return the registered Schema whose ``file_name()`` matches *sub_table*.
+
+        For MULTI schemas the lookup key is ``<file_name>.<sub_name>``, in which
+        case a synthetic SINGLE sub-schema is returned. ``None`` is returned
+        when no registered schema matches — coercion is then skipped.
+        """
+        if not self._schemas:
+            return None
+        return schema_table_map(self._schemas).get(sub_table)
+
     def _load_datasource_from_db(self, dataset_name: str) -> Optional[BASEDATASOURCE]:
         info = self._db_catalogue.get(dataset_name)
         if not info:
@@ -289,6 +302,9 @@ class DatabaseDataManager(DataManager):
                     params={"sid": self._session_id, "name": dataset_name},
                 )
             df = df.drop(columns=[SESSION_COL, DATASET_COL], errors="ignore")
+            schema = self._schema_for_subtable(sub)
+            if schema is not None:
+                df = coerce_dataframe_to_schema(df, schema)
             tables[sub] = df
         ds.from_sql_tables(tables)
         self.log(
@@ -409,7 +425,7 @@ def _decode_sub_tables(raw: Optional[str]) -> Optional[List[str]]:
         return None
     try:
         value = json.loads(raw)
-    except (TypeError, ValueError):
+    except TypeError, ValueError:
         return None
     if isinstance(value, list):
         return [str(v) for v in value]

--- a/packages/algomancy-data/src/algomancy_data/database/schema_translator.py
+++ b/packages/algomancy-data/src/algomancy_data/database/schema_translator.py
@@ -8,6 +8,7 @@ at runtime and are not suitable for declarative FK constraints.
 
 from typing import List, Type
 
+import pandas as pd
 import sqlalchemy as sa
 
 from ..schema import Column, DataType, Schema
@@ -46,3 +47,59 @@ def column_to_sa(col: Column) -> sa.Column:
 def schema_to_sa_columns(schema: Type[Schema]) -> List[sa.Column]:
     """Return a list of ``sqlalchemy.Column`` objects for a SINGLE-type schema."""
     return [column_to_sa(col) for col in schema.columns()]
+
+
+# Per-DataType target pandas dtype used by ``coerce_dataframe_to_schema``.
+# Nullable dtypes are used wherever a SQL round-trip can reintroduce nulls
+# (e.g. INTEGER ↔ float64 once a NaN appears).
+_DTYPE_TO_PANDAS: dict[DataType, str] = {
+    DataType.STRING: "string",
+    DataType.INTEGER: "Int64",
+    DataType.FLOAT: "Float64",
+    DataType.BOOLEAN: "boolean",
+    DataType.CATEGORICAL: "category",
+}
+
+
+def coerce_dataframe_to_schema(df: pd.DataFrame, schema: Type[Schema]) -> pd.DataFrame:
+    """Coerce *df* columns to the dtypes declared by *schema*.
+
+    Called after ``pd.read_sql()`` to restore dtypes lost across the SQL
+    round-trip. Columns absent from the schema are left untouched. Columns
+    declared by the schema but missing from *df* are left missing (a
+    downstream Schema/Required-column validator reports that case).
+
+    Failures on individual columns leave that column untouched rather than
+    aborting the load — the divergence will surface in the next validator
+    run instead of crashing reload.
+
+    MULTI schemas should be reduced to a synthetic SINGLE sub-schema by the
+    caller (e.g. via ``Schema.get_subschema(sub_name)``) before being passed
+    here.
+    """
+    if not schema.is_single():
+        return df
+
+    out = df
+    copied = False
+    for col_name, target in schema.datatypes().items():
+        if col_name not in out.columns:
+            continue
+        try:
+            if target == DataType.DATETIME:
+                new_series = pd.to_datetime(out[col_name], errors="coerce")
+            elif target == DataType.INTERVAL:
+                # Stored as string; no canonical pandas dtype to coerce to.
+                continue
+            else:
+                pandas_dtype = _DTYPE_TO_PANDAS.get(target)
+                if pandas_dtype is None or str(out[col_name].dtype) == pandas_dtype:
+                    continue
+                new_series = out[col_name].astype(pandas_dtype)
+        except TypeError, ValueError:
+            continue
+        if not copied:
+            out = out.copy()
+            copied = True
+        out[col_name] = new_series
+    return out

--- a/packages/algomancy-data/src/algomancy_data/validator.py
+++ b/packages/algomancy-data/src/algomancy_data/validator.py
@@ -333,7 +333,7 @@ class SchemaValidator(Validator):
         return self.messages
 
 
-def _schema_table_map(schemas: List[Schema]) -> Dict[str, Schema]:
+def schema_table_map(schemas: List[Schema]) -> Dict[str, Schema]:
     """Map every expected table name (incl. multi-sheet keys) to its schema class.
 
     For SINGLE schemas the table key equals the file name. For MULTI schemas
@@ -349,6 +349,10 @@ def _schema_table_map(schemas: List[Schema]) -> Dict[str, Schema]:
                     sub_name
                 )
     return table_map
+
+
+# Back-compat alias; prefer ``schema_table_map``.
+_schema_table_map = schema_table_map
 
 
 class RequiredColumnsValidator(Validator):

--- a/packages/algomancy-data/tests/test_database_manager.py
+++ b/packages/algomancy-data/tests/test_database_manager.py
@@ -330,3 +330,137 @@ class TestSharedTableLayout:
             ).fetchall()
         names = {row[0] for row in remaining}
         assert names == {"keep_me"}
+
+
+# ------------------------------------------------------------------ #
+# Regression tests for issue #221: dtype coercion on SQL round-trip
+# ------------------------------------------------------------------ #
+
+
+class TypedSchema(Schema):
+    """Schema exercising the dtypes that drift across the SQLite round-trip."""
+
+    _FILENAME = "typed"
+    _EXTENSION = FileExtension.CSV
+    _SCHEMA_TYPE = SchemaType.SINGLE
+
+    ID = Column(name="id", dtype=DataType.STRING, primary_key=True)
+    FLAG = Column(name="flag", dtype=DataType.BOOLEAN)
+    COUNT = Column(name="count", dtype=DataType.INTEGER, nullable=True)
+    WHEN = Column(name="when", dtype=DataType.DATETIME, nullable=True)
+
+
+@pytest.fixture
+def typed_dm(engine):
+    manager = DatabaseDataManager(
+        etl_factory=SimpleETLFactory,
+        schemas=[TypedSchema()],
+        engine=engine,
+        session_id="typed",
+        data_object_type=DataSource,
+    )
+    manager.startup()
+    return manager
+
+
+class TestDatabaseDataManagerDtypeRoundTrip:
+    """Issue #221 — DataFrames returned by ``get_data`` must match the dtypes
+    declared by the registered Schema, even though SQLite normalises them
+    across the round-trip."""
+
+    def _reload(self, dm: DatabaseDataManager, name: str) -> pd.DataFrame:
+        dm._data.clear()
+        ds = dm.get_data(name)
+        assert ds is not None
+        return ds.tables["typed"]
+
+    def test_boolean_column_survives_roundtrip(self, typed_dm):
+        ds = DataSource(ds_type=DataClassification.MASTER_DATA, name="bools")
+        ds.add_table(
+            "typed",
+            pd.DataFrame(
+                {
+                    "id": ["a", "b"],
+                    "flag": [True, False],
+                    "count": [1, 2],
+                    "when": pd.to_datetime(["2026-01-01", "2026-01-02"]),
+                }
+            ),
+        )
+        typed_dm.add_data_source(ds)
+
+        df = self._reload(typed_dm, "bools")
+        assert str(df["flag"].dtype) == "boolean", (
+            f"BOOLEAN must round-trip as nullable boolean, got {df['flag'].dtype}"
+        )
+        assert df["flag"].tolist() == [True, False]
+
+    def test_integer_with_nan_survives_roundtrip(self, typed_dm):
+        ds = DataSource(ds_type=DataClassification.MASTER_DATA, name="ints")
+        ds.add_table(
+            "typed",
+            pd.DataFrame(
+                {
+                    "id": ["a", "b", "c"],
+                    "flag": [True, False, True],
+                    # pandas stores this as float64 because of the None
+                    "count": [1, None, 3],
+                    "when": pd.to_datetime(["2026-01-01", "2026-01-02", "2026-01-03"]),
+                }
+            ),
+        )
+        typed_dm.add_data_source(ds)
+
+        df = self._reload(typed_dm, "ints")
+        assert str(df["count"].dtype) == "Int64", (
+            f"INTEGER must round-trip as nullable Int64, got {df['count'].dtype}"
+        )
+        assert df["count"].iloc[0] == 1
+        assert pd.isna(df["count"].iloc[1])
+        assert df["count"].iloc[2] == 3
+
+    def test_datetime_survives_roundtrip(self, typed_dm):
+        ds = DataSource(ds_type=DataClassification.MASTER_DATA, name="times")
+        ds.add_table(
+            "typed",
+            pd.DataFrame(
+                {
+                    "id": ["a"],
+                    "flag": [True],
+                    "count": [1],
+                    "when": pd.to_datetime(["2026-06-10 12:34:56"]),
+                }
+            ),
+        )
+        typed_dm.add_data_source(ds)
+
+        df = self._reload(typed_dm, "times")
+        assert str(df["when"].dtype) == "datetime64[ns]", (
+            f"DATETIME must round-trip as datetime64[ns], got {df['when'].dtype}"
+        )
+        assert df["when"].iloc[0] == pd.Timestamp("2026-06-10 12:34:56")
+
+    def test_unknown_subtable_skipped_silently(self, engine):
+        """A sub-table with no matching Schema must load without coercion or
+        raising — preserves behaviour for ad-hoc / test DataSources."""
+        dm = DatabaseDataManager(
+            etl_factory=SimpleETLFactory,
+            schemas=[ItemSchema()],  # only knows "item"
+            engine=engine,
+            session_id="unknown",
+            data_object_type=DataSource,
+        )
+        dm.startup()
+        ds = DataSource(ds_type=DataClassification.MASTER_DATA, name="ad_hoc")
+        ds.add_table(
+            "ad_hoc_table",  # not declared in any schema
+            pd.DataFrame({"x": [1, 2, 3]}),
+        )
+        dm.add_data_source(ds)
+
+        dm._data.clear()
+        reloaded = dm.get_data("ad_hoc")
+        assert reloaded is not None
+        assert "ad_hoc_table" in reloaded.tables
+        # No coercion applied — pandas-inferred dtype passes through.
+        assert reloaded.tables["ad_hoc_table"]["x"].tolist() == [1, 2, 3]


### PR DESCRIPTION
## Summary

- `DatabaseDataManager` was reading sub-tables back through `pd.read_sql` without consulting the declared `Schema`, so SQLite-backed `BOOLEAN` columns came back as `int64`, nullable `INTEGER` as `float64`, and `DATETIME` as `object`. Downstream code that relied on the declared dtype (e.g. dataclasses with `bool` fields) silently received the wrong type.
- `_load_datasource_from_db` now looks up the Schema whose `file_name()` matches each sub-table and coerces the DataFrame with a new `coerce_dataframe_to_schema` helper in `schema_translator`. Sub-tables without a matching schema are unaffected.
- `validator._schema_table_map` is promoted to a public `schema_table_map` (thin alias kept for back-compat) so it can be reused by `DatabaseDataManager`.

Issue ranks the fix at must-have / nice-to-have / defense-in-depth; this PR is the must-have read-side coercion only.

## Test plan

- [x] `uv run pytest packages/algomancy-data/tests/test_database_manager.py -v` — 14 passed, including 4 new tests in `TestDatabaseDataManagerDtypeRoundTrip` (boolean / int+NaN / datetime / unknown-subtable-skipped).
- [x] `uv run pytest packages/algomancy-data/tests -v` — 248 passed.
- [x] `uv run pytest tests -v` — 47 passed, 1 skipped.
- [x] `ruff check` + `ruff format` clean on all touched files.

Closes #221.