### PR TITLE
fixed new_scenario_window session id threading

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,13 @@
 
 > Migrating from v0.5 or earlier? See the [migration guide](migration-ref)
 > for before/after snippets covering every breaking change in v0.6–v0.7.
+ 
+
+## v0.9.2
+### Fixed
+- The new-scenario parameters window now resolves algorithm/data parameter templates through the active session's 
+   `ScenarioManager` instead of a nonexistent `SessionManager` method.
+
 ## v0.9.1
 ### Added
 - **`ApiConfiguration.forwarded_allow_ips`** — opt-in support for `X-Forwarded-Proto` / `X-Forwarded-For`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,8 @@
 
 import os
 import sys
+import tomllib
+from pathlib import Path
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -14,7 +16,8 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "Algomancy"
 copyright = "2026, Pepijn Wissing"
 author = "Pepijn Wissing"
-release = "0.3.16"
+with (Path(__file__).resolve().parents[2] / "pyproject.toml").open("rb") as _f:
+    release = tomllib.load(_f)["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/packages/algomancy-api/pyproject.toml
+++ b/packages/algomancy-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-api"
-version = "0.9.1"
+version = "0.9.2"
 description = "FastAPI HTTP interface exposing Algomancy scenario/data management to remote frontends."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/algomancy-content/pyproject.toml
+++ b/packages/algomancy-content/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-content"
-version = "0.9.1"
+version = "0.9.2"
 description = "Placeholder content for quick start to the Algomancy library"
 readme = "README.md"
 authors = [

--- a/packages/algomancy-data/pyproject.toml
+++ b/packages/algomancy-data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-data"
-version = "0.9.1"
+version = "0.9.2"
 description = "Data management model for the Algomancy library"
 readme = "README.md"
 authors = [

--- a/packages/algomancy-gui/pyproject.toml
+++ b/packages/algomancy-gui/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-gui"
-version = "0.9.1"
+version = "0.9.2"
 description = "Dash components for the Algomancy library"
 readme = "README.md"
 authors = [

--- a/packages/algomancy-gui/src/algomancy_gui/scenario_page/new_scenario_parameters_window.py
+++ b/packages/algomancy-gui/src/algomancy_gui/scenario_page/new_scenario_parameters_window.py
@@ -1,5 +1,4 @@
-from algomancy_gui.managers.managergetters import get_manager
-from algomancy_gui.managers.sessionmanager import SessionManager
+from algomancy_gui.managers.managergetters import get_scenario_manager
 from algomancy_gui.managers.settingsmanager import SettingsManager
 import dash_bootstrap_components as dbc
 from dash import html, get_app, dcc
@@ -127,9 +126,13 @@ def create_input_group(
     return form_groups
 
 
-def create_algo_parameters_entry_card_body(template_name: str) -> dbc.CardBody:
-    session_manager: SessionManager | ScenarioManager = get_manager(get_app().server)
-    algo_params: BaseParameterSet = session_manager.get_algorithm_parameters(
+def create_algo_parameters_entry_card_body(
+    template_name: str, session_id: str
+) -> dbc.CardBody:
+    scenario_manager: ScenarioManager = get_scenario_manager(
+        get_app().server, session_id
+    )
+    algo_params: BaseParameterSet = scenario_manager.get_algorithm_parameters(
         template_name
     )
     assert algo_params.has_inputs(), "No parameters found for algorithm template."
@@ -145,9 +148,13 @@ def create_algo_parameters_entry_card_body(template_name: str) -> dbc.CardBody:
     )
 
 
-def create_data_parameters_entry_card_body(dataset_key: str) -> dbc.CardBody:
-    session_manager: SessionManager | ScenarioManager = get_manager(get_app().server)
-    data_params: BaseParameterSet = session_manager.get_data_parameters(dataset_key)
+def create_data_parameters_entry_card_body(
+    dataset_key: str, session_id: str
+) -> dbc.CardBody:
+    scenario_manager: ScenarioManager = get_scenario_manager(
+        get_app().server, session_id
+    )
+    data_params: BaseParameterSet = scenario_manager.get_data_parameters(dataset_key)
     assert data_params.has_inputs(), "No data parameters declared by this dataset."
     input_group = create_input_group(
         data_params.get_parameters(),

--- a/packages/algomancy-gui/src/algomancy_gui/scenario_page/scenarios.py
+++ b/packages/algomancy-gui/src/algomancy_gui/scenario_page/scenarios.py
@@ -365,7 +365,7 @@ def refresh_on_close(is_open):
 def open_algo_params_window(algo_name, session_id):
     if algo_name:
         try:
-            return True, create_algo_parameters_entry_card_body(algo_name)
+            return True, create_algo_parameters_entry_card_body(algo_name, session_id)
         except AssertionError:
             return no_update, ""
     return no_update, ""
@@ -381,7 +381,7 @@ def open_algo_params_window(algo_name, session_id):
 def populate_data_params_card(dataset_key, session_id):
     if dataset_key:
         try:
-            return True, create_data_parameters_entry_card_body(dataset_key)
+            return True, create_data_parameters_entry_card_body(dataset_key, session_id)
         except AssertionError:
             return no_update, ""
     return no_update, ""

--- a/packages/algomancy-quickstart/pyproject.toml
+++ b/packages/algomancy-quickstart/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-quickstart"
-version = "0.9.1"
+version = "0.9.2"
 description = "Interactive CLI wizard for setting up Algomancy applications."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/algomancy-scenario/pyproject.toml
+++ b/packages/algomancy-scenario/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-scenario"
-version = "0.9.1"
+version = "0.9.2"
 description = "Scenario management model for the Algomancy library"
 readme = "README.md"
 authors = [

--- a/packages/algomancy-utils/pyproject.toml
+++ b/packages/algomancy-utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "algomancy-utils"
-version = "0.9.1"
+version = "0.9.2"
 description = "Miscellaneous modules used in the Algomancy library"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ classifiers = [
   "Programming Language :: Python"
 ]
 dependencies = [
-  "algomancy-api >= 0.9.1",
-  "algomancy-content >= 0.9.1",
-  "algomancy-data >= 0.9.1",
-  "algomancy-gui >= 0.9.1",
-  "algomancy-scenario >= 0.9.1",
-  "algomancy-utils >= 0.9.1",
-  "algomancy-quickstart >= 0.9.1",
+  "algomancy-api >= 0.9.2",
+  "algomancy-content >= 0.9.2",
+  "algomancy-data >= 0.9.2",
+  "algomancy-gui >= 0.9.2",
+  "algomancy-scenario >= 0.9.2",
+  "algomancy-utils >= 0.9.2",
+  "algomancy-quickstart >= 0.9.2",
   "furo>=2025.12.19",
   "ipykernel>=7.2.0",
   "myst-parser>=5.0.0",
@@ -47,7 +47,7 @@ maintainers = [
 name = "Algomancy"
 readme = "README.md"
 requires-python = ">=3.14"
-version = "0.9.1"
+version = "0.9.2"
 
 [project.optional-dependencies]
 database = [

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ wheels = [
 
 [[package]]
 name = "algomancy"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "algomancy-api" },
@@ -119,7 +119,7 @@ dev = [
 
 [[package]]
 name = "algomancy-api"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-api" }
 dependencies = [
     { name = "algomancy-data" },
@@ -154,7 +154,7 @@ dev = [
 
 [[package]]
 name = "algomancy-content"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-content" }
 dependencies = [
     { name = "algomancy-data" },
@@ -177,7 +177,7 @@ requires-dist = [
 
 [[package]]
 name = "algomancy-data"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-data" }
 dependencies = [
     { name = "algomancy-utils" },
@@ -205,7 +205,7 @@ provides-extras = ["database"]
 
 [[package]]
 name = "algomancy-gui"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-gui" }
 dependencies = [
     { name = "algomancy-content" },
@@ -234,7 +234,7 @@ requires-dist = [
 
 [[package]]
 name = "algomancy-quickstart"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-quickstart" }
 dependencies = [
     { name = "algomancy-content" },
@@ -259,7 +259,7 @@ requires-dist = [
 
 [[package]]
 name = "algomancy-scenario"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-scenario" }
 dependencies = [
     { name = "algomancy-data" },
@@ -285,7 +285,7 @@ provides-extras = ["database"]
 
 [[package]]
 name = "algomancy-utils"
-version = "0.9.1"
+version = "0.9.2"
 source = { editable = "packages/algomancy-utils" }
 dependencies = [
     { name = "strenum" },


### PR DESCRIPTION
Fix session_id threading in new-scenario parameter windows

**Problem**

- Opening the "new scenario" dialog and selecting an algorithm or dataset raised AttributeError: 'SessionManager' object has no attribute 'get_data_parameters' (and would have hit the equivalent for algorithm parameters too).

**Root cause**

-   `create_algo_parameters_entry_card_body` and `create_data_parameters_entry_card_body` resolved a bare SessionManager via `get_manager(server)` and called get_algorithm_parameters/get_data_parameters directly on it — but those parameter-lookup methods live on the session's ScenarioManager, not on SessionManager
-   itself. The correct resolver, `get_scenario_manager(server, session_id)`, was available but unused, and the calling Dash callbacks in scenarios.py already had session_id in scope (as a State) but never passed it down.

**Fix**

- `create_algo_parameters_entry_card_body` / `create_data_parameters_entry_card_body` now take session_id and resolve the correct per-session ScenarioManager via get_scenario_manager, then call get_algorithm_parameters / get_data_parameters on that instance.
- scenarios.py's open_algo_params_window and populate_data_params_card callbacks now pass their existing session_id through to those functions instead of discarding it.
- Dropped the now-unused get_manager/SessionManager imports from new_scenario_parameters_window.py.